### PR TITLE
Make glossary filterable

### DIFF
--- a/static/assets/js/enhanced-glossary.js
+++ b/static/assets/js/enhanced-glossary.js
@@ -1,0 +1,22 @@
+export const init = () => {
+  const jsRequired = document.querySelector(".js-required");
+  jsRequired.style.display = "block";
+
+  const input = document.getElementById("filter-input");
+  input.addEventListener("keyup", updateResults);
+};
+
+const updateResults = () => {
+  const input = document.getElementById("filter-input");
+  const filter = input.value.toUpperCase();
+  const termElements = document.querySelectorAll(".term");
+
+  // Loop through all terms, and hide those who don't match the search query
+  termElements.forEach((el) => {
+    if (filter == "" || el.dataset.term.startsWith(filter)) {
+      el.classList.remove("govuk-!-display-none");
+    } else {
+      el.classList.add("govuk-!-display-none");
+    }
+  });
+};

--- a/static/assets/js/enhanced-glossary.js
+++ b/static/assets/js/enhanced-glossary.js
@@ -27,8 +27,10 @@ const updateResults = () => {
 
   // Loop through all term groups, and hide those without visible terms
   termGroups.forEach((el) => {
-    const terms = el.querySelectorAll(".term:not(.govuk-\\!-display-none)");
-    const isEmpty = terms.length === 0;
+    const terms = Array.from(el.querySelectorAll(".term"));
+    const isEmpty =
+      terms.length === 0 ||
+      terms.every((term) => term.classList.contains("govuk-!-display-none"));
 
     if (isEmpty) {
       el.classList.add("govuk-!-display-none");

--- a/static/assets/js/enhanced-glossary.js
+++ b/static/assets/js/enhanced-glossary.js
@@ -10,13 +10,30 @@ const updateResults = () => {
   const input = document.getElementById("filter-input");
   const filter = input.value.toUpperCase();
   const termElements = document.querySelectorAll(".term");
+  const termGroups = document.querySelectorAll(".term-group");
 
   // Loop through all terms, and hide those who don't match the search query
   termElements.forEach((el) => {
-    if (filter == "" || el.dataset.term.startsWith(filter)) {
+    if (
+      filter == "" ||
+      el.dataset.term.startsWith(filter) ||
+      el.dataset.term.includes(" " + filter)
+    ) {
       el.classList.remove("govuk-!-display-none");
     } else {
       el.classList.add("govuk-!-display-none");
+    }
+  });
+
+  // Loop through all term groups, and hide those without visible terms
+  termGroups.forEach((el) => {
+    const terms = el.querySelectorAll(".term:not(.govuk-\\!-display-none)");
+    const isEmpty = terms.length === 0;
+
+    if (isEmpty) {
+      el.classList.add("govuk-!-display-none");
+    } else {
+      el.classList.remove("govuk-!-display-none");
     }
   });
 };

--- a/templates/base/navigation.html
+++ b/templates/base/navigation.html
@@ -38,7 +38,7 @@
             </a>
           </li>
           <li class="govuk-header__navigation-item {% if request.path == glossary_url %}govuk-header__navigation-item--active{%endif%}">
-            <a class="govuk-header__link" href="{% url 'home:glossary' %}?new=True">
+            <a class="govuk-header__link" href="{% url 'home:glossary' %}">
               Glossary
             </a>
           </li>

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -1,5 +1,6 @@
 {% extends "base/base.html" %}
 {% load markdown %}
+{% load static %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -7,15 +8,9 @@
     <h1 class="govuk-heading-l">Glossary</h1>
   </div>
   <div class="govuk-grid-column-three-quarters">
-    <div class="search-container govuk-form-group govuk-!-margin-bottom-8">
-        <label for="{{ form.query.id_for_label }}" class="govuk-label govuk-visually-hidden-focusable">Search MOJ Data</label>
-        <input class="govuk-input search-input" placeholder="Filter this page">
-        <button class="search-button" type="submit" id="search-button">
-          <svg aria-hidden="true" class="search-icon" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width="40" height="40">
-            <path d="M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z" fill="currentColor"></path>
-          </svg>
-          <label for="search-button" class="govuk-label govuk-visually-hidden-focusable">Search MOJ Data</label>
-        </button>
+    <div class="govuk-form-group govuk-!-margin-bottom-8 js-required">
+        <label for="filter-input" class="govuk-label govuk-visually-hidden-focusable">Filter this page</label>
+        <input class="govuk-input" id="filter-input" placeholder="Filter this page">
     </div>
   </div>
 </div>
@@ -45,7 +40,7 @@
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
         </div>
             {% for member in parent_term.members %}
-            <div class="term">
+            <div data-term="{{member.name|upper}}" class="term">
                 <h2 class="govuk-heading-m" id="{{ member.name }}">{{ member.name }}</h2>
                 <p class="govuk-body">{{ member.description|markdown }}</p>
             </div>
@@ -56,3 +51,9 @@
 </div>
 
 {% endblock content %}
+{% block scripts %}
+<script type="module">
+    import {init} from "{% static 'assets/js/enhanced-glossary.js' %}"
+    init();
+  </script>
+{% endblock scripts %}

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -9,7 +9,7 @@
   </div>
   <div class="govuk-grid-column-three-quarters">
     <div class="govuk-form-group govuk-!-margin-bottom-8 js-required">
-        <label for="filter-input" class="govuk-label govuk-visually-hidden-focusable">Filter this page</label>
+        <label for="filter-input" class="govuk-label govuk-visually-hidden-focusable">Filter this page (the content will be updated as you type)</label>
         <input class="govuk-input" id="filter-input" placeholder="Filter this page">
     </div>
   </div>

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -38,7 +38,7 @@
             <h1 class="govuk-heading-l" id="{{ parent_term }}">{{ parent_term.name }}</h1>
             <p class="govuk-body-l">{{ parent_term.description }}</p>
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-        </div>
+
             {% for member in parent_term.members %}
             <div data-term="{{member.name|upper}}" class="term">
                 <h2 class="govuk-heading-m" id="{{ member.name }}">{{ member.name }}</h2>
@@ -46,6 +46,7 @@
             </div>
             {%endfor%}
             <br>
+        </div>
         {%endfor%}
     </div>
 </div>

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -18,12 +18,12 @@
     <div class="govuk-grid-column-one-quarter" id="sticky-sidebar">
         <ul class="govuk-list">
             {% for parent_term in results %}
-            <li>
+            <li class="term-group">
                 <div><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="#{{ parent_term }}">
                     <strong>{{ parent_term.name }}</strong>
                 </a></div>
                 {% for member in parent_term.members %}
-                    <div><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="#{{ member.name }}">
+                    <div data-term="{{member.name|upper}}" class="term"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="#{{ member.name }}">
                         {{ member.name }}
                     </a></div>
                 {%endfor%}

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -35,13 +35,13 @@
     <div class="govuk-grid-column-three-quarters">
         {% for parent_term in results %}
         <div class="term-group">
-            <h1 class="govuk-heading-l" id="{{ parent_term }}">{{ parent_term.name }}</h1>
+            <h2 class="govuk-heading-l" id="{{ parent_term }}">{{ parent_term.name }}</h2>
             <p class="govuk-body-l">{{ parent_term.description }}</p>
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
             {% for member in parent_term.members %}
             <div data-term="{{member.name|upper}}" class="term">
-                <h2 class="govuk-heading-m" id="{{ member.name }}">{{ member.name }}</h2>
+                <h3 class="govuk-heading-m" id="{{ member.name }}">{{ member.name }}</h3>
                 <p class="govuk-body">{{ member.description|markdown }}</p>
             </div>
             {%endfor%}

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -6,6 +6,18 @@
   <div class="govuk-grid-column-one-quarter">
     <h1 class="govuk-heading-l">Glossary</h1>
   </div>
+  <div class="govuk-grid-column-three-quarters">
+    <div class="search-container govuk-form-group govuk-!-margin-bottom-8">
+        <label for="{{ form.query.id_for_label }}" class="govuk-label govuk-visually-hidden-focusable">Search MOJ Data</label>
+        <input class="govuk-input search-input" placeholder="Filter this page">
+        <button class="search-button" type="submit" id="search-button">
+          <svg aria-hidden="true" class="search-icon" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width="40" height="40">
+            <path d="M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z" fill="currentColor"></path>
+          </svg>
+          <label for="search-button" class="govuk-label govuk-visually-hidden-focusable">Search MOJ Data</label>
+        </button>
+    </div>
+  </div>
 </div>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-quarter" id="sticky-sidebar">
@@ -27,13 +39,13 @@
     </div>
     <div class="govuk-grid-column-three-quarters">
         {% for parent_term in results %}
-        <div>
+        <div class="term-group">
             <h1 class="govuk-heading-l" id="{{ parent_term }}">{{ parent_term.name }}</h1>
             <p class="govuk-body-l">{{ parent_term.description }}</p>
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
         </div>
             {% for member in parent_term.members %}
-            <div>
+            <div class="term">
                 <h2 class="govuk-heading-m" id="{{ member.name }}">{{ member.name }}</h2>
                 <p class="govuk-body">{{ member.description|markdown }}</p>
             </div>

--- a/tests/javascript/test_enhanced_glossary.js
+++ b/tests/javascript/test_enhanced_glossary.js
@@ -1,0 +1,66 @@
+import { init } from "enhanced-glossary";
+import { expect, test } from "@jest/globals";
+
+const simplifiedPage = `
+<div class="js-required">
+<input class="govuk-input" id="filter-input" placeholder="Filter this page">
+<div id="things" class="term-group">
+  <h2>Things</h2>
+  <p>Bla bla bla</p>
+  <hr>
+
+  <div id="apple" data-term="APPLE" class="term">
+      <h3>Apple</h3>
+      <p>Apples apples apples</p>
+  </div>
+
+  <div id="banana" data-term="BANANA" class="term">
+      <h3>Banana</h3>
+      <p>Banananaananaa</p>
+  </div>
+</div>
+</div>
+`;
+
+let filter;
+let apple;
+let banana;
+let things;
+
+beforeEach(() => {
+  document.body.innerHTML = simplifiedPage;
+
+  filter = document.getElementById("filter-input");
+  apple = document.getElementById("apple");
+  banana = document.getElementById("banana");
+  things = document.getElementById("things");
+
+  init();
+});
+
+test("everything is shown when the filter is empty", () => {
+  filter.value = "";
+  filter.dispatchEvent(new Event("keyup"));
+
+  expect(things).not.toHaveClass("govuk-!-display-none");
+  expect(apple).not.toHaveClass("govuk-!-display-none");
+  expect(banana).not.toHaveClass("govuk-!-display-none");
+});
+
+test("filtering to a term by its prefix", () => {
+  filter.value = "ap";
+  filter.dispatchEvent(new Event("keyup"));
+
+  expect(things).not.toHaveClass("govuk-!-display-none");
+  expect(apple).not.toHaveClass("govuk-!-display-none");
+  expect(banana).toHaveClass("govuk-!-display-none");
+});
+
+test("filtering out all terms within a group", () => {
+  filter.value = "carrot";
+  filter.dispatchEvent(new Event("keyup"));
+
+  expect(things).toHaveClass("govuk-!-display-none");
+  expect(apple).toHaveClass("govuk-!-display-none");
+  expect(banana).toHaveClass("govuk-!-display-none");
+});


### PR DESCRIPTION
This adds some client side code to make the glossary filterable. If javascript is disabled the filter is not displayed.

Figma: https://www.figma.com/file/zTOVhHRnWfxRJqH6Gr8cIc/Catalogue-sketches?type=design&node-id=511-4866&mode=design&t=7XRs7hEdAhSyLSfn-0

The page updates as you type in the filter. This pattern is based on https://ministry-of-justice-acronyms.service.justice.gov.uk/

It works by toggling the `govuk-!-display-none` based on whether the filter matches elements.

Terms are matched if any word within the term begins with the filter (case insensitive).

https://github.com/ministryofjustice/find-moj-data/assets/87579/8dd73cfe-9f7e-4d09-8c63-824e00a0a5f9

