### PR TITLE
Move datahub deployment from private repo

### DIFF
--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -1,4 +1,4 @@
-name: deploy-dev
+name: Deploy staged
 
 on:
   push:

--- a/.github/workflows/deploy-staged.yml
+++ b/.github/workflows/deploy-staged.yml
@@ -1,0 +1,45 @@
+name: deploy-dev
+
+on:
+  push:
+    paths:
+      - 'helm_deploy/**'
+      - '.github/workflows/**'
+      - '!helm_deploy/**test**'
+      - '!.github/workflows/**test**'
+    branches: 
+      - 'main'
+
+jobs:
+  deploy-dev:
+    uses: ./.github/workflows/deploy-workflow.yml
+    with:
+      env: dev
+      datahub_helm_version: "0.3.30"
+      datahub_prereqs_helm_version: "0.1.8"
+    secrets:
+      kube_namespace: "${{ secrets.KUBE_NAMESPACE }}"
+      kube_cert: "${{ secrets.KUBE_CERT }}"
+      kube_cluster: "${{ secrets.KUBE_CLUSTER }}"
+      kube_token: "${{ secrets.KUBE_TOKEN }}"
+      postgres_host: ${{ secrets.POSTGRES_HOST}}
+      postgres_client_host: ${{ secrets.POSTGRES_CLIENT_HOST }} 
+      postgres_url: ${{ secrets.POSTGRES_URL }}
+      opensearch_proxy_host: ${{ secrets.OPENSEARCH_PROXY_HOST }}
+
+  deploy-preprod:
+    uses: ./.github/workflows/deploy-workflow.yml
+    needs: [deploy-dev]
+    with:
+      env: preprod
+      datahub_helm_version: "0.3.30"
+      datahub_prereqs_helm_version: "0.1.8"
+    secrets:
+      kube_namespace: "${{ secrets.KUBE_NAMESPACE }}"
+      kube_cert: "${{ secrets.KUBE_CERT }}"
+      kube_cluster: "${{ secrets.KUBE_CLUSTER }}"
+      kube_token: "${{ secrets.KUBE_TOKEN }}"
+      postgres_host: ${{ secrets.POSTGRES_HOST}}
+      postgres_client_host: ${{ secrets.POSTGRES_CLIENT_HOST }} 
+      postgres_url: ${{ secrets.POSTGRES_URL }}
+      opensearch_proxy_host: ${{ secrets.OPENSEARCH_PROXY_HOST }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,22 @@
+name: deploy-test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  deploy-test:
+    uses: ./.github/workflows/deploy-workflow.yml
+    with:
+      env: test
+      datahub_helm_version: "0.3.30"
+      datahub_prereqs_helm_version: "0.1.8"
+    secrets:
+      kube_namespace: "${{ secrets.KUBE_NAMESPACE }}"
+      kube_cert: "${{ secrets.KUBE_CERT }}"
+      kube_cluster: "${{ secrets.KUBE_CLUSTER }}"
+      kube_token: "${{ secrets.KUBE_TOKEN }}"
+      postgres_host: ${{ secrets.POSTGRES_HOST}}
+      postgres_client_host: ${{ secrets.POSTGRES_CLIENT_HOST }} 
+      postgres_url: ${{ secrets.POSTGRES_URL }}
+      opensearch_proxy_host: ${{ secrets.OPENSEARCH_PROXY_HOST }}

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -1,0 +1,165 @@
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      env:
+        description: 'which environment to deploy to'
+        required: true
+        type: string
+      datahub_helm_version:
+        description: 'version of the datahub helm chart to use for deploy'
+        required: true
+        type: string
+      datahub_prereqs_helm_version:
+        description: 'version of the datahub prerequisites helm chart to use for deploy'
+        required: true
+        type: string
+    secrets:
+      kube_namespace:
+        description: 'the kubernetes namespace to deploy to'
+        required: true
+      kube_cert:
+        description: 'cert used to verify identity to cluster'
+        required: true
+      kube_cluster:
+        description: 'address of the cluster to connect to'
+        required: true
+      kube_token:
+        description: 'used to authenticate to the cluster'
+        required: true
+      postgres_host: 
+        description: 'address of the metadata database, including port'
+        required: true
+      postgres_client_host:
+        description: 'address of the metadata database, without port'
+        required: true
+      postgres_url:
+        description: 'URI including the scheme designator (prefix) and database name'
+        required: true
+      opensearch_proxy_host:  
+        description: 'domain address to reach opensearch'
+        required: true
+
+concurrency: 
+  group: ${{ inputs.env }}
+
+jobs:
+  deploy:
+    name: Deploy Helm Chart into Cloud Platform
+    environment: ${{ inputs.env }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # This is required for actions/checkout
+      id-token: write # This is required for requesting the JWT
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create cert certificate-authority
+        id: create-cert-authority
+        shell: bash
+        run: echo "${{ secrets.kube_cert }}" > ca.crt
+
+      - name: Authenticate to the cluster
+        shell: bash
+        id: authenticate
+        env:
+          KUBE_CLUSTER: ${{ secrets.kube_cluster }}
+        run: |
+          kubectl config set-cluster "${KUBE_CLUSTER}" --certificate-authority=ca.crt --server="https://${KUBE_CLUSTER}"
+          kubectl config set-credentials deploy-user --token="${{ secrets.kube_token }}"
+          kubectl config set-context "${KUBE_CLUSTER}" --cluster="${KUBE_CLUSTER}" --user=deploy-user --namespace="${{ secrets.kube_namespace }}"
+          kubectl config use-context "${KUBE_CLUSTER}"
+
+      - name: Create users-secret if it doesn't exist
+        shell: bash
+        id: create-users-secret-if-not-exists
+        env: 
+          KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
+          RELEASE_NAME: datahub
+        run: |
+          NS_SECRETS=$(kubectl get secrets -n ${KUBE_NAMESPACE} -o=jsonpath='{range .items..metadata}{.name}{"\n"}{end}')
+          
+          USERS_SECRET_NAME=$(echo ${NS_SECRETS} | egrep "${RELEASE_NAME}-users-secret" || exit_code=$?
+          if (( exit_code > 1 )) ; then
+              exit $exit_code
+          fi)
+
+          if [[ -z ${USERS_SECRET_NAME} ]]; then
+            echo "users-secret doesn't exist. Creating..."
+
+            USER_PASS=$(openssl rand -base64 12)
+            
+            cat >/tmp/user.props <<EOL
+            // new user.props
+            datahub:${USER_PASS}
+          EOL
+            
+            kubectl create secret generic "${RELEASE_NAME}-users-secret" --from-file=/tmp/user.props -n ${KUBE_NAMESPACE} 
+          fi
+
+      - name: add helm repo
+        shell: bash
+        id: add-helm-repo
+        continue-on-error: true
+        run: |
+          helm repo add datahub https://helm.datahubproject.io/
+
+      - name: update helm repos
+        shell: bash
+        id: update-helm-repo
+        continue-on-error: true
+        run: |
+          helm repo update datahub
+
+      - name: install datahub pre-requisites charts
+        shell: bash
+        id: upgrade-helm-prereqs
+        env:
+          CHART_VERSION: ${{ inputs.datahub_prereqs_helm_version }}
+        run: |
+          helm upgrade \
+          --install prerequisites datahub/datahub-prerequisites \
+          --version ${CHART_VERSION} \
+          --atomic --timeout 5m0s \
+          --values helm_deploy/values_prerequisites-base.yaml \
+          --namespace ${{ secrets.kube_namespace }}
+
+      - name: set host names
+        env: 
+          KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
+          BASE_HOST: apps.live.cloud-platform.service.justice.gov.uk
+          RELEASE_NAME: datahub
+        run: |-
+          echo "BASE_HOST=${BASE_HOST}" >> $GITHUB_ENV 
+          echo "APP_SHORT_HOST=${KUBE_NAMESPACE/data-platform-/}.${BASE_HOST}" >> $GITHUB_ENV
+          echo "EXT_DNS_ID=${RELEASE_NAME}-datahub-frontend-${KUBE_NAMESPACE}-green" >> $GITHUB_ENV
+          
+      - name: install datahub helm charts
+        env:
+          POSTGRES_HOST: ${{ secrets.postgres_host }}
+          POSTGRES_CLIENT_HOST: ${{ secrets.postgres_client_host }}
+          POSTGRES_URL: ${{ secrets.postgres_url }}
+          OPENSEARCH_PROXY_HOST: ${{ secrets.OPENSEARCH_PROXY_HOST }}
+          APP_SHORT_HOST: ${{ env.APP_SHORT_HOST }}
+          RELEASE_NAME: datahub
+          CHART_VERSION: ${{ inputs.datahub_helm_version }}
+        # if many env-specific variables need setting, add --values files after 'base'
+        # e.g. `--values helm_deploy/values-${{ inputs.env }}.yaml \` 
+        run: |
+          helm upgrade \
+          --install ${RELEASE_NAME} datahub/datahub \
+          --version ${CHART_VERSION} \
+          --atomic --timeout 10m0s \
+          --values helm_deploy/values-base.yaml \
+          --namespace ${{ secrets.kube_namespace }} \
+          --set "datahub-frontend.oidcAuthentication.azureTenantId=${{ vars.TENANT_ID }}" \
+          --set "datahub-frontend.oidcAuthentication.clientId=${{ vars.CLIENT_ID }}" \
+          --set "datahub-frontend.ingress.tls[0].hosts[0]=${APP_SHORT_HOST}" \
+          --set "datahub-frontend.ingress.hosts[0].host=${APP_SHORT_HOST}" \
+          --set "datahub-frontend.ingress.annotations.external-dns\\.alpha\\.kubernetes\\.io/set-identifier=${EXT_DNS_ID}" \
+          --set global.elasticsearch.host=${OPENSEARCH_PROXY_HOST} \
+          --set global.sql.datasource.host=${POSTGRES_HOST} \
+          --set global.sql.datasource.hostForpostgresqlClient=${POSTGRES_CLIENT_HOST} \
+          --set global.sql.datasource.url=${POSTGRES_URL}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ lite_sink.yaml:
 ```yaml
 pipeline_name: datahub_source_1
 datahub_api:
-  server: "https://data-platform-datahub-catalogue-dev.apps.live.cloud-platform.service.justice.gov.uk/api/gms"
+  server: "https://datahub-catalogue-dev.apps.live.cloud-platform.service.justice.gov.uk/api/gms"
   token: "xxxxx"
 source:
   type: datahub

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![repo standards badge](https://img.shields.io/endpoint?labelColor=231f20&color=005ea5&style=for-the-badge&label=MoJ%20Compliant&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fendpoint%2Fdata-catalogue&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAABmJLR0QA/wD/AP+gvaeTAAAHJElEQVRYhe2YeYyW1RWHnzuMCzCIglBQlhSV2gICKlHiUhVBEAsxGqmVxCUUIV1i61YxadEoal1SWttUaKJNWrQUsRRc6tLGNlCXWGyoUkCJ4uCCSCOiwlTm6R/nfPjyMeDY8lfjSSZz3/fee87vnnPu75z3g8/kM2mfqMPVH6mf35t6G/ZgcJ/836Gdug4FjgO67UFn70+FDmjcw9xZaiegWX29lLLmE3QV4Glg8x7WbFfHlFIebS/ANj2oDgX+CXwA9AMubmPNvuqX1SnqKGAT0BFoVE9UL1RH7nSCUjYAL6rntBdg2Q3AgcAo4HDgXeBAoC+wrZQyWS3AWcDSUsomtSswEtgXaAGWlVI2q32BI0spj9XpPww4EVic88vaC7iq5Hz1BvVf6v3qe+rb6ji1p3pWrmtQG9VD1Jn5br+Knmm70T9MfUh9JaPQZu7uLsR9gEsJb3QF9gOagO7AuUTom1LpCcAkoCcwQj0VmJregzaipA4GphNe7w/MBearB7QLYCmlGdiWSm4CfplTHwBDgPHAFmB+Ah8N9AE6EGkxHLhaHU2kRhXc+cByYCqROs05NQq4oR7Lnm5xE9AL+GYC2gZ0Jmjk8VLKO+pE4HvAyYRnOwOH5N7NhMd/WKf3beApYBWwAdgHuCLn+tatbRtgJv1awhtd838LEeq30/A7wN+AwcBt+bwpD9AdOAkYVkpZXtVdSnlc7QI8BlwOXFmZ3oXkdxfidwmPrQXeA+4GuuT08QSdALxC3OYNhBe/TtzON4EziZBXD36o+q082BxgQuqvyYL6wtBY2TyEyJ2DgAXAzcC1+Xxw3RlGqiuJ6vE6QS9VGZ/7H02DDwAvELTyMDAxbfQBvggMAAYR9LR9J2cluH7AmnzuBowFFhLJ/wi7yiJgGXBLPq8A7idy9kPgvAQPcC9wERHSVcDtCfYj4E7gr8BRqWMjcXmeB+4tpbyG2kG9Sl2tPqF2Uick8B+7szyfvDhR3Z7vvq/2yqpynnqNeoY6v7LvevUU9QN1fZ3OTeppWZmeyzRoVu+rhbaHOledmoQ7LRd3SzBVeUo9Wf1DPs9X90/jX8m/e9Rn1Mnqi7nuXXW5+rK6oU7n64mjszovxyvVh9WeDcTVnl5KmQNcCMwvpbQA1xE8VZXhwDXAz4FWIkfnAlcBAwl6+SjD2wTcmPtagZnAEuA3dTp7qyNKKe8DW9UeBCeuBsbsWKVOUPvn+MRKCLeq16lXqLPVFvXb6r25dlaGdUx6cITaJ8fnpo5WI4Wuzcjcqn5Y8eI/1F+n3XvUA1N3v4ZamIEtpZRX1Y6Z/DUK2g84GrgHuDqTehpBCYend94jbnJ34DDgNGArQT9bict3Y3p1ZCnlSoLQb0sbgwjCXpY2blc7llLW1UAMI3o5CD4bmuOlwHaC6xakgZ4Z+ibgSxnOgcAI4uavI27jEII7909dL5VSrimlPKgeQ6TJCZVQjwaOLaW8BfyWbPEa1SaiTH1VfSENd85NDxHt1plA71LKRvX4BDaAKFlTgLeALtliDUqPrSV6SQCBlypgFlbmIIrCDcAl6nPAawmYhlLKFuB6IrkXAadUNj6TXlhDcCNEB/Jn4FcE0f4UWEl0NyWNvZxGTs89z6ZnatIIrCdqcCtRJmcCPwCeSN3N1Iu6T4VaFhm9n+riypouBnepLsk9p6p35fzwvDSX5eVQvaDOzjnqzTl+1KC53+XzLINHd65O6lD1DnWbepPBhQ3q2jQyW+2oDkkAtdt5udpb7W+Q/OFGA7ol1zxu1tc8zNHqXercfDfQIOZm9fR815Cpt5PnVqsr1F51wI9QnzU63xZ1o/rdPPmt6enV6sXqHPVqdXOCe1rtrg5W7zNI+m712Ir+cer4POiqfHeJSVe1Raemwnm7xD3mD1E/Z3wIjcsTdlZnqO8bFeNB9c30zgVG2euYa69QJ+9G90lG+99bfdIoo5PU4w362xHePxl1slMab6tV72KUxDvzlAMT8G0ZohXq39VX1bNzzxij9K1Qb9lhdGe931B/kR6/zCwY9YvuytCsMlj+gbr5SemhqkyuzE8xau4MP865JvWNuj0b1YuqDkgvH2GkURfakly01Cg7Cw0+qyXxkjojq9Lw+vT2AUY+DlF/otYq1Ixc35re2V7R8aTRg2KUv7+ou3x/14PsUBn3NG51S0XpG0Z9PcOPKWSS0SKNUo9Rv2Mmt/G5WpPF6pHGra7Jv410OVsdaz217AbkAPX3ubkm240belCuudT4Rp5p/DyC2lf9mfq1iq5eFe8/lu+K0YrVp0uret4nAkwlB6vzjI/1PxrlrTp/oNHbzTJI92T1qAT+BfW49MhMg6JUp7ehY5a6Tl2jjmVvitF9fxo5Yq8CaAfAkzLMnySt6uz/1k6bPx59CpCNxGfoSKA30IPoH7cQXdArwCOllFX/i53P5P9a/gNkKpsCMFRuFAAAAABJRU5ErkJggg==)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/data-catalogue)
 
-This is the root repository for the MOJ data catalogue.
+This is the root repository for the MOJ data catalogue, and contains the deployment workflows
+for the Datahub backend.
 
 ## Component repositories
 
@@ -10,12 +11,23 @@ This is the root repository for the MOJ data catalogue.
 - [data-catalogue-metadata](https://github.com/ministryofjustice/data-catalogue-metadata) (internal) contains JSON files used to populate the catalogue in development
 
 ## Environments
+
 - [Datahub (dev)](https://datahub-catalogue-dev.apps.live.cloud-platform.service.justice.gov.uk/)
 - [Find MOJ data (dev)](https://data-platform-find-moj-data-dev.apps.live.cloud-platform.service.justice.gov.uk/)
 
-## Datahub (Backend)
+## Managing database secrets
 
-### Administration via command line
+The [k8s-rds-secrets-to-github-secrets.sh](/scripts/k8s-rds-secrets-to-github-secrets.sh) script can be used from a local device to populate this repo's environment secrets with the database secrets for the datahub environments deployed in cloud platform.
+
+It can be called as
+
+`bash k8s-rds-secrets-to-github-secrets <namespace root> <CP environment name>`
+
+for example:
+
+`bash k8s-rds-secrets-to-github-secrets.sh data-platform-datahub-catalogue dev`
+
+## Administration of Datahub via command line
 
 #### First time setup
 
@@ -35,7 +47,7 @@ lite_sink.yaml:
 ```yaml
 pipeline_name: datahub_source_1
 datahub_api:
-  server: "https://data-platform-datahub-catalogue-dev.apps.live.cloud-platform.service.justice.gov.uk/api/gms" 
+  server: "https://data-platform-datahub-catalogue-dev.apps.live.cloud-platform.service.justice.gov.uk/api/gms"
   token: "xxxxx"
 source:
   type: datahub

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -1,0 +1,460 @@
+# Values to start up datahub after starting up the datahub-prerequisites chart with "prerequisites" release name
+datahub-gms:
+  enabled: true
+  image:
+    repository: linkedin/datahub-gms
+  securityContext:
+    runAsUser: 100
+  resources:
+    limits:
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 1Gi
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    failureThreshold: 8
+  readinessProbe:
+    initialDelaySeconds: 120
+    periodSeconds: 30
+    failureThreshold: 8
+  service:
+    type: ClusterIP
+
+datahub-frontend:
+  enabled: true
+  image:
+    repository: linkedin/datahub-frontend-react
+    # tag: "v0.10.0" # # defaults to .global.datahub.version
+  extraVolumes:
+    - name: datahub-users
+      secret:
+        defaultMode: 0444
+        secretName:  datahub-users-secret
+  extraVolumeMounts:
+    - name: datahub-users
+      mountPath: /datahub-frontend/conf/user.props
+      subPath: user.props
+  extraEnvs:
+    - name: "AUTH_OIDC_EXTRACT_GROUPS_ENABLED"
+      value: "true"
+    # Allow both user/pass login & SSO authentication https://datahubproject.io/docs/authentication/guides/add-users/
+    - name: "AUTH_JAAS_ENABLED"
+      value: "true"
+    - name: "OPENSEARCH_USE_AWS_IAM_AUTH"
+      value: "true"
+  service:
+    type: ClusterIP
+  lifecycle:
+    {}
+  resources:
+    limits:
+      memory: 1400Mi
+    requests:
+      cpu: 100m
+      memory: 512Mi
+  podSecurityContext:
+    fsGroup: 101
+  securityContext:
+    runAsUser: 100
+  # Set up ingress to expose react front-end
+  ingress:
+    enabled: true
+    className: default
+    annotations:
+      external-dns.alpha.kubernetes.io/set-identifier: ""
+      external-dns.alpha.kubernetes.io/aws-weight: "100"
+    tls:
+      - hosts:
+          - ""
+    hosts:
+      - host: ""
+        paths:
+          - /
+  oidcAuthentication:
+    enabled: true
+    provider: azure
+    clientId: ""
+    clientSecretRef:
+      secretRef: azure-secrets
+      secretKey: client_secret
+    azureTenantId: ""
+    # user_name_claim: "email" # default "email"
+    # user_name_claim_regex: "([^@]+)" # "([^@]+)"
+  # opt-in to metadata service auth for frontend proxy service: https://github.com/acryldata/datahub/blob/master/docs/authentication/introducing-metadata-service-authentication.md#configuring-metadata-service-authentication
+  auth:
+    enabled: true
+
+acryl-datahub-actions:
+  enabled: true
+  podSecurityContext:
+    fsGroup: 103
+  securityContext:
+    runAsUser: 102
+  image:
+    repository: acryldata/datahub-actions
+    tag: "v0.0.13"
+  # mount the k8s secret as a volume in the container, each key name is mounted as a 
+  # file on the mount path /etc/datahub/ingestion-secret-files
+  # ingestionSecretFiles:
+  #   name: ${K8S_SECRET_NAME}
+  #   defaultMode: "0444"
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+
+datahub-ingestion-cron:
+  enabled: false
+
+elasticsearchSetupJob:
+  enabled: true
+  serviceAccount: ""
+  image:
+    repository: linkedin/datahub-elasticsearch-setup
+    tag: "4f1a399" # defaults to .global.datahub.version
+  extraEnvs:
+    - name: USE_AWS_ELASTICSEARCH
+      value: "true"
+    - name: OPENSEARCH_USE_AWS_IAM_AUTH
+      value: "true"
+
+kafkaSetupJob:
+  enabled: true
+  image:
+    repository: linkedin/datahub-kafka-setup
+    # tag: "v0.11.0" # defaults to .global.datahub.version
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 768Mi
+  extraInitContainers: []
+  podSecurityContext:
+    fsGroup: 101
+  securityContext:
+    runAsUser: 1000
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
+  podAnnotations: {}
+  extraSidecars: []
+
+mysqlSetupJob:
+  enabled: false
+
+postgresqlSetupJob:
+  enabled: true
+  image:
+    repository: acryldata/datahub-postgres-setup
+    # tag: "v0.11.0" # defaults to .global.datahub.version
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 300m
+      memory: 256Mi
+  extraInitContainers: []
+  podSecurityContext:
+    fsGroup: 101
+  securityContext:
+    runAsUser: 1000
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
+  podAnnotations: {}
+  extraSidecars: []
+  extraEnvs:
+    - name: "DATAHUB_DB_NAME"
+      valueFrom:
+        secretKeyRef:
+          name: rds-postgresql-instance-output
+          key: database_name
+
+## No code data migration
+datahubUpgrade:
+  enabled: true
+  image:
+    repository: acryldata/datahub-upgrade
+    # tag: "v0.11.0"  # defaults to .global.datahub.version
+  batchSize: 1000
+  batchDelayMs: 100
+  noCodeDataMigration:
+    sqlDbType: "POSTGRES"
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-2"
+    helm.sh/hook-delete-policy: before-hook-creation
+  podSecurityContext:
+    fsGroup: 101
+  securityContext:
+    runAsUser: 100
+  podAnnotations: {}
+  extraSidecars: []
+  cleanupJob:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 300m
+        memory: 256Mi
+    concurrencyPolicy: Allow
+    extraSidecars: []
+  restoreIndices:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 300m
+        memory: 256Mi
+    concurrencyPolicy: Allow
+    extraSidecars: []
+    extraEnvs:
+      - name: "DATAHUB_DB_NAME"
+        valueFrom:
+          secretKeyRef:
+            name: rds-postgresql-instance-output
+            key: database_name
+  extraInitContainers: []
+
+## Runs system update processes
+## Includes: Elasticsearch Indices Creation/Reindex (See global.elasticsearch.index for additional configuration)
+datahubSystemUpdate:
+  image:
+    repository: acryldata/datahub-upgrade
+    # tag:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-4"
+    helm.sh/hook-delete-policy: before-hook-creation
+  podSecurityContext:
+    fsGroup: 101
+  securityContext:
+    runAsUser: 100
+  podAnnotations: {}
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 300m
+      memory: 256Mi
+  extraSidecars: []
+  extraInitContainers: []
+
+global:
+  strict_mode: true
+  graph_service_impl: elasticsearch
+  datahub_analytics_enabled: true
+  datahub_standalone_consumers_enabled: false
+
+  elasticsearch:
+    #  The host is the core of the proxy url (minus "https://" prefix and ":port" suffix)
+    host: ""
+    port: "8080"
+    useSSL: "false"
+
+    ## The following section controls when and how reindexing of elasticsearch indices are performed
+    index:
+      ## Enable reindexing when mappings change based on the data model annotations
+      enableMappingsReindex: true
+
+      ## Enable reindexing when static index settings change.
+      ## Dynamic settings which do not require reindexing are not affected
+      ## Primarily this should be enabled when re-sharding is necessary for scaling/performance.
+      enableSettingsReindex: true
+
+      ## Index settings can be overridden for entity indices or other indices on an index by index basis
+      ## Some index settings, such as # of shards, requires reindexing while others, i.e. replicas, do not
+      ## Non-Entity indices do not require the prefix
+      # settingsOverrides: '{"graph_service_v1":{"number_of_shards":"5"},"system_metadata_service_v1":{"number_of_shards":"5"}}'
+      ## Entity indices do not require the prefix or suffix
+      # entitySettingsOverrides: '{"dataset":{"number_of_shards":"10"}}'
+
+      ## The amount of delay between indexing a document and having it returned in queries
+      ## Increasing this value can improve performance when ingesting large amounts of data
+      # refreshIntervalSeconds: 1
+
+      ## The following options control settings for datahub-upgrade job when creating or reindexing indices
+      upgrade:
+        ## When reindexing is required, this option will clone the existing index as a backup
+        ## The clone indices are not currently managed.
+        cloneIndices: true
+
+        ## Typically when reindexing the document counts between the original and destination indices should match.
+        ## In some cases reindexing might not be able to proceed due to incompatibilities between a document in the
+        ## orignal index and the new index's mappings. This document could be dropped and re-ingested or restored from
+        ## the SQL database.
+        ##
+        ## This setting allows continuing if and only if the cloneIndices setting is also enabled which
+        ## ensures a complete backup of the original index is preserved.
+        allowDocCountMismatch: false
+
+    ## Search related configuration
+    search:
+      ## Maximum terms in aggregations
+      maxTermBucketSize: 20
+
+      ## Configuration around exact matching for search
+      exactMatch:
+        ## if false will only apply weights, if true will exclude non-exact
+        exclusive: false
+        ## include prefix exact matches
+        withPrefix: true
+        ## boost multiplier when exact with case
+        exactFactor: 2.0
+        ## boost multiplier when exact prefix
+        prefixFactor: 1.6
+        ## stacked boost multiplier when case mismatch
+        caseSensitivityFactor: 0.7
+        ## enable exact match on structured search
+        enableStructured: true
+
+      ## Configuration for graph service dao
+      graph:
+        ## graph dao timeout seconds
+        timeoutSeconds: 50
+        ## graph dao batch size
+        batchSize: 1000
+        ## graph dao max result size
+        maxResult: 10000
+
+      custom:
+        enabled: false
+        # See documentation: https://datahubproject.io/docs/how/search/#customizing-search
+        # default config: https://github.com/acryldata/datahub-helm/blob/master/charts/datahub/values.yaml#L481-L554
+
+  kafka:
+    bootstrap:
+      server: "prerequisites-kafka:9092"
+    zookeeper:
+      server: "prerequisites-zookeeper:2181"
+    # This section defines the names for the kafka topics that DataHub depends on, at a global level. Do not override this config
+    # at a sub-chart level.
+    topics:
+      metadata_change_event_name: "MetadataChangeEvent_v4"
+      failed_metadata_change_event_name: "FailedMetadataChangeEvent_v4"
+      metadata_audit_event_name: "MetadataAuditEvent_v4"
+      datahub_usage_event_name: "DataHubUsageEvent_v1"
+      metadata_change_proposal_topic_name: "MetadataChangeProposal_v1"
+      failed_metadata_change_proposal_topic_name: "FailedMetadataChangeProposal_v1"
+      metadata_change_log_versioned_topic_name: "MetadataChangeLog_Versioned_v1"
+      metadata_change_log_timeseries_topic_name: "MetadataChangeLog_Timeseries_v1"
+      platform_event_topic_name: "PlatformEvent_v1"
+      datahub_upgrade_history_topic_name: "DataHubUpgradeHistory_v1"
+    maxMessageBytes: "5242880" # 5MB
+    producer:
+      compressionType: none
+      maxRequestSize: "5242880" # 5MB
+    consumer:
+      maxPartitionFetchBytes: "5242880" # 5MB
+    ## For AWS MSK set this to a number larger than 1
+    # partitions: 3
+    # replicationFactor: 3
+    schemaregistry:
+      # GMS Implementation - `url` configured based on component context
+      type: INTERNAL
+      # Glue Implementation - `url` not applicable
+      # type: AWS_GLUE
+      # glue:
+      #   region: us-east-1
+      #   registry: datahub
+
+  sql:
+    datasource:
+      host: ""
+      # as host, minus ":port"
+      hostForpostgresqlClient: ""
+      port: "5432"
+      # url is format "jdbc:postgresql://{host}/{database_name}"
+      url: ""
+      driver: "org.postgresql.Driver"
+      username:
+        secretRef: rds-postgresql-instance-output
+        secretKey: database_username
+      password:
+        secretRef: rds-postgresql-instance-output
+        secretKey: database_password
+      extraEnvs:
+        - name: "DATAHUB_DB_NAME"
+          valueFrom:
+            secretKeyRef:
+              name: rds-postgresql-instance-output
+              key: database_name
+
+
+  datahub:
+    version: v0.12.0
+    gms:
+      port: "8080"
+      nodePort: "30001"
+
+    frontend:
+      validateSignUpEmail: true
+
+    monitoring:
+      enablePrometheus: true
+
+    mae_consumer:
+      port: "9091"
+      nodePort: "30002"
+
+    appVersion: "1.0"
+    systemUpdate:
+      ## The following options control settings for datahub-upgrade job which will
+      ## managed ES indices and other update related work
+      enabled: true
+
+    encryptionKey:
+      secretRef: "datahub-encryption-secrets"
+      secretKey: "encryption_key_secret"
+      provisionSecret:
+        enabled: true
+        autoGenerate: true
+        annotations: {}
+
+    managed_ingestion:
+      enabled: true
+      defaultCliVersion: "0.12.0"
+
+    metadata_service_authentication:
+      enabled: true
+      systemClientId: "__datahub_system"
+      systemClientSecret:
+        secretRef: "datahub-auth-secrets"
+        secretKey: "system_client_secret"
+      tokenService:
+        signingKey:
+          secretRef: "datahub-auth-secrets"
+          secretKey: "token_service_signing_key"
+        salt:
+          secretRef: "datahub-auth-secrets"
+          secretKey: "token_service_salt"
+      provisionSecrets:
+        enabled: true
+        autoGenerate: true
+        annotations: {}
+
+    ## Enables always emitting a MCL even when no changes are detected. Used for Time Based Lineage when no changes occur.
+    alwaysEmitChangeLog: false
+
+    ## Enables diff mode for graph writes, uses a different code path that produces a diff from previous to next to write relationships instead of wholesale deleting edges and reading
+    enableGraphDiffMode: true
+
+    ## Values specific to the unified search and browse feature.
+    search_and_browse:
+      show_search_v2: true
+      show_browse_v2: true
+      # If on, run the backfill upgrade job that generates default browse paths for relevant entities
+      backfill_browse_v2: true

--- a/helm_deploy/values_prerequisites-base.yaml
+++ b/helm_deploy/values_prerequisites-base.yaml
@@ -1,0 +1,114 @@
+# Default configuration for pre-requisites to get you started
+# Copy this file and update to the configuration of choice
+elasticsearch:
+  enabled: false # set this to false, if you want to provide your own ES instance.
+
+# Official neo4j chart, supports both community and enterprise editions
+# see https://neo4j.com/docs/operations-manual/current/kubernetes/ for more information
+# source: https://github.com/neo4j/helm-charts
+neo4j:
+  enabled: false
+  nameOverride: neo4j
+  neo4j:
+    name: neo4j
+    edition: "community"
+    acceptLicenseAgreement: "yes"
+    defaultDatabase: "graph.db"
+    password: "datahub"
+    # For better security, add password to neo4j-secrets k8s secret with  neo4j-username neo4j-passwordn and NEO4J_AUTH and uncomment below
+    # NEO4J_AUTH: should be composed like so: {Username}/{Password}
+    # passwordFromSecret: neo4j-secrets
+
+  # Set security context for pod
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 7474
+    runAsGroup: 7474
+    fsGroup: 7474
+    fsGroupChangePolicy: "Always"
+
+  # Disallow privilegeEscalation on container level
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+
+  # Create a volume for neo4j, SSD storage is recommended
+  volumes:
+    {}
+    # data:
+    #   mode: "dynamic"
+    #   dynamic:
+    #     storageClassName: managed-csi-premium
+
+  env:
+    NEO4J_PLUGINS: '["apoc"]'
+
+mysql:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+# Using gcloud-proxy requires the node in a GKE cluster to have Cloud SQL Admin scope,
+# you will need to create a new node and migrate the workload if your current node does not have this scope
+gcloud-sqlproxy:
+  enabled: false
+
+cp-helm-charts:
+  enabled: false
+  # Schema registry is under the community  license
+  cp-schema-registry:
+    enabled: false
+    securityContext:
+      runAsUser: 10001
+      runAsGroup: 10001
+      fsGroup: 10001
+      runAsNonRoot: true
+    kafka:
+      bootstrapServers: "prerequisites-kafka:9092" # <<release-name>>-kafka:9092
+  cp-kafka:
+    enabled: false
+  cp-zookeeper:
+    enabled: false
+  cp-kafka-rest:
+    enabled: false
+  cp-kafka-connect:
+    enabled: false
+  cp-ksql-server:
+    enabled: false
+  cp-control-center:
+    enabled: false
+
+# Bitnami version of Kafka that deploys open source Kafka https://artifacthub.io/packages/helm/bitnami/kafka
+kafka:
+  enabled: true
+  listeners:
+    client:
+      protocol: PLAINTEXT
+    interbroker:
+      protocol: PLAINTEXT
+  controller:
+    replicaCount: 0
+  broker:
+    replicaCount: 2
+    # The new minId for broker is 100. If we don't override this, the broker will have id 100
+    # and cannot load the partitions. So we set minId to 0 to be backwards compatible
+    minId: 0
+    # These server properties are no longer exposed as parameters in the bitnami kafka chart since 24.0.0
+    # They need to be passed in through extraConfig. See below for reference
+    # https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2400
+    extraConfig: |
+      message.max.bytes=5242880
+      default.replication.factor=1
+      offsets.topic.replication.factor=1
+      transaction.state.log.replication.factor=1
+  kraft:
+    enabled: false
+  zookeeper:
+    enabled: true
+  resources:
+    limits:
+      cpu: 400m
+      memory: 1600Mi
+    requests:
+      cpu: 80m
+      memory: 1000Mi

--- a/scripts/k8s-rds-secrets-to-github-secrets.sh
+++ b/scripts/k8s-rds-secrets-to-github-secrets.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -euo errexit
+set -o pipefail
+
+# check if kubectl is installed
+if ! [ -x "$(command -v kubectl)" ]; then
+  echo 'Error: kubectl is not installed.' >&2
+  exit 1
+fi
+
+# check if gh is installed
+if ! [ -x "$(command -v gh)" ]; then
+  echo 'Error: gh (github cli) is not installed.' >&2
+  exit 1
+fi
+
+# Usage function (optional, for clarity)
+usage() {
+  echo "Usage: ./k8s-rds-secrets-to-github-secrets.sh <kubernetes_namespace_root> <github_environment_name>"
+}
+
+# Process arguments and handle dry run
+DRY_RUN=false
+while getopts ":d" opt; do
+  case ${opt} in
+    d) DRY_RUN=true 
+       ;;
+    \?) echo "Invalid option: -$OPTARG" >&2
+        usage
+        exit 2
+        ;;  
+  esac
+done
+shift $((OPTIND -1))
+
+# Check for required arguments
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+GITHUB_REPO="ministryofjustice/data-catalogue"
+RDS_SECRET_NAME="rds-postgresql-instance-output"
+OS_SECRET_NAME="data-platform-opensearch-proxy-url"
+
+GITHUB_ENV_NAME="$2"
+KUBE_NAMESPACE="$1-$GITHUB_ENV_NAME"
+
+# Get Kubernetes secret YAML and decode
+RDS_SECRET_YAML=$(kubectl -n "$KUBE_NAMESPACE" get secret $RDS_SECRET_NAME -o yaml)
+
+# Extract values from YAML (replacing Ruby logic)
+RDS_INSTANCE_ADDRESS=$(echo "$RDS_SECRET_YAML" | grep 'rds_instance_address:' | awk '{print $2}' | base64 -d)
+RDS_INSTANCE_ENDPOINT=$(echo "$RDS_SECRET_YAML" | grep 'rds_instance_endpoint:' | awk '{print $2}' | base64 -d)
+DB_NAME=$(echo "$RDS_SECRET_YAML" | grep 'database_name:' | awk '{print $2}' | base64 -d)
+RDS_URL="jdbc:postgresql://${RDS_INSTANCE_ENDPOINT}/${DB_NAME}"
+
+OS_SECRET_YAML=$(kubectl -n "$KUBE_NAMESPACE" get secret $OS_SECRET_NAME -o yaml)
+OS_PROXY_URL=$(echo "$OS_SECRET_YAML" | grep 'proxy_url:' | awk '{print $2}' | base64 -d)
+OS_PROXY_URL=$(echo "$OS_PROXY_URL" | sed -E 's|^https?://||' | sed -E 's|:[0-9]+$||')
+
+if [[ $DRY_RUN == true ]]; then
+  echo "** DRY RUN **"
+  echo "KUBE_NAMESPACE: $KUBE_NAMESPACE"
+  echo "Would set GitHub secrets:"
+  echo "- POSTGRES_CLIENT_HOST=$RDS_INSTANCE_ADDRESS"
+  echo "- POSTGRES_HOST=$RDS_INSTANCE_ENDPOINT"
+  echo "- POSTGRES_URL=$RDS_URL"
+  echo "- OPENSEARCH_PROXY_HOST=$OS_PROXY_URL"
+else
+  # Set GitHub secrets (assuming you have GitHub CLI installed and configured)
+  gh secret set POSTGRES_CLIENT_HOST \
+    --body $RDS_INSTANCE_ADDRESS \
+    --env $GITHUB_ENV_NAME \
+    --repo $GITHUB_REPO 
+  gh secret set POSTGRES_HOST \
+    --body $RDS_INSTANCE_ENDPOINT \
+    --env $GITHUB_ENV_NAME \
+    --repo $GITHUB_REPO 
+  gh secret set POSTGRES_URL \
+    --body $RDS_URL \
+    --env $GITHUB_ENV_NAME \
+    --repo $GITHUB_REPO 
+  gh secret set OPENSEARCH_PROXY_HOST \
+    --body $OS_PROXY_URL \
+    --env $GITHUB_ENV_NAME \
+    --repo $GITHUB_REPO 
+fi
+
+exit 0


### PR DESCRIPTION
Merge the private deployment repo into the public data-catalogue one. The plan is for this repo to be the parent repo for the service, which signposts any additional repos we need.

Secrets are managed via AWS secrets manager & Kubernetes secrets, so there should be nothing sensitive in these values.

I've run the following

```
matt.moore@MJ004284 scripts % bash k8s-rds-secrets-to-github-secrets.sh data-platform-datahub-catalogue dev
✓ Set Actions secret POSTGRES_CLIENT_HOST for ministryofjustice/data-catalogue
✓ Set Actions secret POSTGRES_HOST for ministryofjustice/data-catalogue
✓ Set Actions secret POSTGRES_URL for ministryofjustice/data-catalogue
✓ Set Actions secret OPENSEARCH_PROXY_HOST for ministryofjustice/data-catalogue
matt.moore@MJ004284 scripts % bash k8s-rds-secrets-to-github-secrets.sh data-platform-datahub-catalogue test
✓ Set Actions secret POSTGRES_CLIENT_HOST for ministryofjustice/data-catalogue
✓ Set Actions secret POSTGRES_HOST for ministryofjustice/data-catalogue
✓ Set Actions secret POSTGRES_URL for ministryofjustice/data-catalogue
✓ Set Actions secret OPENSEARCH_PROXY_HOST for ministryofjustice/data-catalogue
matt.moore@MJ004284 scripts % bash k8s-rds-secrets-to-github-secrets.sh data-platform-datahub-catalogue preprod
✓ Set Actions secret POSTGRES_CLIENT_HOST for ministryofjustice/data-catalogue
✓ Set Actions secret POSTGRES_HOST for ministryofjustice/data-catalogue
✓ Set Actions secret POSTGRES_URL for ministryofjustice/data-catalogue
✓ Set Actions secret OPENSEARCH_PROXY_HOST for ministryofjustice/data-catalogue
```

## Prerequisites
We will need to merge the following cloud platform PRs
- [x] [Test](https://github.com/ministryofjustice/cloud-platform-environments/pull/21838)
- [ ] [Dev](https://github.com/ministryofjustice/cloud-platform-environments/pull/21839)
- [ ] [Preprod](https://github.com/ministryofjustice/cloud-platform-environments/pull/21840)