### PR TITLE
add `inputs.env` to frontend fullname to enable ingress filtering

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -134,7 +134,7 @@ jobs:
         run: |-
           echo "BASE_HOST=${BASE_HOST}" >> $GITHUB_ENV 
           echo "APP_SHORT_HOST=${KUBE_NAMESPACE/data-platform-/}.${BASE_HOST}" >> $GITHUB_ENV
-          echo "EXT_DNS_ID=${RELEASE_NAME}-datahub-frontend-${KUBE_NAMESPACE}-green" >> $GITHUB_ENV
+          echo "EXT_DNS_ID=${RELEASE_NAME}-datahub-frontend-${{ inputs.env }}-${KUBE_NAMESPACE}-green" >> $GITHUB_ENV
 
       - name: install datahub helm charts
         env:

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -146,6 +146,7 @@ jobs:
           POSTGRES_HOST: ${{ secrets.postgres_host }}
           POSTGRES_URL: ${{ secrets.postgres_url }}
           RELEASE_NAME: datahub
+          FRONTEND_FULLNAME: datahub-frontend-${{ inputs.env }}
         # if many env-specific variables need setting, add --values files after 'base'
         # e.g. `--values helm_deploy/values-${{ inputs.env }}.yaml \`
         run: |
@@ -155,6 +156,7 @@ jobs:
           --atomic --timeout 10m0s \
           --values helm_deploy/values-base.yaml \
           --namespace ${{ secrets.kube_namespace }} \
+          --set datahub-frontend.fullnameOverride=${RELEASE_NAME}-${FRONTEND_FULLNAME} \
           --set "datahub-frontend.oidcAuthentication.azureTenantId=${{ vars.TENANT_ID }}" \
           --set "datahub-frontend.oidcAuthentication.clientId=${{ vars.CLIENT_ID }}" \
           --set "datahub-frontend.ingress.tls[0].hosts[0]=${APP_SHORT_HOST}" \

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -26,6 +26,7 @@ datahub-gms:
 
 datahub-frontend:
   enabled: true
+  fullnameOverride: ""
   image:
     repository: acryldata/datahub-frontend-react
     # tag: "v0.10.0" # # defaults to .global.datahub.version


### PR DESCRIPTION
Changing the ingress name to allow filtering by ingress name only (otherwise all `data-platform-datahub-catalogue-` namespace environments share the same ingress name) - see [Cloud Platform NGINX ingress dashboard](https://grafana.live.cloud-platform.service.justice.gov.uk/d/k8s-nginx-ingress-prometheus-ng2/5178fc76-29af-51b9-83a8-cbab85db37a6?orgId=1&refresh=1m&var-controller_class=All&var-namespace=All&var-ingress=datahub-datahub-frontend-dev&var-pod=All&var-datasource=default).

This requires deleting the ingress and the frontend deployment in the namespace