### PR TITLE
Add deployment monitoring dashboard

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -188,14 +188,14 @@ jobs:
         id: update-grafana-dashboards
         env:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
-          DASHBOARDS: "datahub-status-dashboard datahub-deployment-dashboard"
+          DASHBOARDS_JSON_STRING: '{"datahub-status-dashboard": "datahub-dashboard","datahub-deployment-dashboard": "datahub-deployment-dashboard"}'
         run: |
-          read -a DASHBOARD_NAMES <<< "${DASHBOARDS}"
-          for DASHBOARD in "${DASHBOARD_NAMES[@]}"
-          do
-            echo ${DASHBOARD}
+          DASHBOARDS_JSON=$(jq -n -c "$DASHBOARDS_JSON_STRING")
+          echo $DASHBOARDS_JSON | jq 'to_entries | .[].key' | while read DASHBOARD; do
+            DASHBOARD_FILE=$(echo $DATA | jq -r ".[$DASHBOARD]")
+            
             kubectl create configmap ${DASHBOARD} \
-            --from-file=helm_deploy/monitoring/datahub-dashboard.json \
+            --from-file="helm_deploy/monitoring/${DASHBOARD_FILE}.json" \
             --dry-run \
             --output yaml | 
               kubectl label -f- \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -191,7 +191,6 @@ jobs:
           DASHBOARDS_JSON_STRING: '{"datahub-status-dashboard": "datahub-dashboard","datahub-deployment-dashboard": "datahub-deployment-dashboard"}'
         run: |
           DASHBOARDS_JSON=$(jq -n -c "$DASHBOARDS_JSON_STRING")
-          echo $DASHBOARDS_JSON
           echo $DASHBOARDS_JSON | jq -r 'to_entries | .[].key' | while read DASHBOARD; do
             DASHBOARD_FILE=$(echo $DASHBOARDS_JSON | jq -r --arg e "${DASHBOARD}" '.[$e]')
 

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -126,7 +126,9 @@ jobs:
           --values helm_deploy/values_prerequisites-base.yaml \
           --namespace ${{ secrets.kube_namespace }}
 
-      - name: set host names
+      - name: set env vars
+        shell: bash
+        id: set-envs
         env:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
           BASE_HOST: apps.live.cloud-platform.service.justice.gov.uk
@@ -137,6 +139,8 @@ jobs:
           echo "EXT_DNS_ID=${RELEASE_NAME}-datahub-frontend-${{ inputs.env }}-${KUBE_NAMESPACE}-green" >> $GITHUB_ENV
 
       - name: install datahub helm charts
+        shell: bash
+        id: upgrade-helm-datahub
         env:
           APP_SHORT_HOST: ${{ env.APP_SHORT_HOST }}
           CHART_VERSION: ${{ inputs.datahub_helm_version }}
@@ -168,22 +172,34 @@ jobs:
           --set global.sql.datasource.hostForpostgresqlClient=${POSTGRES_CLIENT_HOST} \
           --set global.sql.datasource.url=${POSTGRES_URL}
 
-      - name: install datahub-monitoring helm
+      - name: allow CP prometheus scraping 
+        if: ${{ inputs.env == 'dev' }}
         shell: bash
+        id: allow-prom-scrape
         env:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
-          DASHBOARD_NAME: datahub-status-dashboard
         run: |
           envsubst < helm_deploy/monitoring/datahub-networkpolicy.yaml | 
             kubectl apply -f - --namespace=${KUBE_NAMESPACE}
 
-          kubectl create configmap ${DASHBOARD_NAME} \
-          --from-file=helm_deploy/monitoring/datahub-dashboard.json \
-          --dry-run \
-          --output yaml | 
-            kubectl label -f- \
+      - name: update grafana dashboard configmaps
+        if: ${{ inputs.env == 'dev' }}
+        shell: bash
+        id: update-grafana-dashboards
+        env:
+          KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
+          DASHBOARDS: ("datahub-status-dashboard", "datahub-deployment-dashboard")
+        run: |
+          for DASHBOARD in $DASHBOARDS
+          do
+            kubectl create configmap ${DASHBOARD} \
+            --from-file=helm_deploy/monitoring/datahub-dashboard.json \
             --dry-run \
-            --output yaml \
-            --local grafana_dashboard=${DASHBOARD_NAME} | 
-            kubectl apply -f- \
-            --namespace=${KUBE_NAMESPACE}
+            --output yaml | 
+              kubectl label -f- \
+              --dry-run \
+              --output yaml \
+              --local grafana_dashboard=${DASHBOARD} | 
+              kubectl apply -f- \
+              --namespace=${KUBE_NAMESPACE}
+          done

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -193,12 +193,7 @@ jobs:
           DASHBOARDS_JSON=$(jq -n -c "$DASHBOARDS_JSON_STRING")
           echo $DASHBOARDS_JSON
           echo $DASHBOARDS_JSON | jq -r 'to_entries | .[].key' | while read DASHBOARD; do
-            DASHBOARD_FILE=$(echo $DATA | jq -r --arg e "${DASHBOARD}" '.[$e]')
-            
-            echo ${DASHBOARD}
-            echo ${DASHBOARD_FILE}
-            echo grafana_dashboard=${DASHBOARD}
-            echo "helm_deploy/monitoring/${DASHBOARD_FILE}.json"
+            DASHBOARD_FILE=$(echo $DASHBOARDS_JSON | jq -r --arg e "${DASHBOARD}" '.[$e]')
 
             kubectl create configmap ${DASHBOARD} \
             --from-file="helm_deploy/monitoring/${DASHBOARD_FILE}.json" \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -188,7 +188,7 @@ jobs:
         id: update-grafana-dashboards
         env:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
-          DASHBOARDS: '["datahub-status-dashboard", "datahub-deployment-dashboard"]''
+          DASHBOARDS: '["datahub-status-dashboard", "datahub-deployment-dashboard"]'
         run: |
           for DASHBOARD in fromJSON(${DASHBOARDS})
           do

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -188,9 +188,9 @@ jobs:
         id: update-grafana-dashboards
         env:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
-          DASHBOARDS: ("datahub-status-dashboard" "datahub-deployment-dashboard")
+          DASHBOARDS: '["datahub-status-dashboard", "datahub-deployment-dashboard"]''
         run: |
-          for DASHBOARD in ${DASHBOARDS}
+          for DASHBOARD in fromJSON(${DASHBOARDS})
           do
             kubectl create configmap ${DASHBOARD} \
             --from-file=helm_deploy/monitoring/datahub-dashboard.json \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -190,8 +190,8 @@ jobs:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
           DASHBOARDS: ("datahub-status-dashboard" "datahub-deployment-dashboard")
         run: |
-          DASHBOARDS="${DASHBOARDS[@]}"
-          for DASHBOARD in "${DASHBOARDS[@]}"
+          DASHBOARD_NAMES="${DASHBOARDS}"
+          for DASHBOARD in "${DASHBOARD_NAMES[@]}"
           do
             echo ${DASHBOARD}
             kubectl create configmap ${DASHBOARD} \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -191,8 +191,9 @@ jobs:
           DASHBOARDS_JSON_STRING: '{"datahub-status-dashboard": "datahub-dashboard","datahub-deployment-dashboard": "datahub-deployment-dashboard"}'
         run: |
           DASHBOARDS_JSON=$(jq -n -c "$DASHBOARDS_JSON_STRING")
+          echo $DASHBOARDS_JSON
           echo $DASHBOARDS_JSON | jq -r 'to_entries | .[].key' | while read DASHBOARD; do
-            DASHBOARD_FILE=$(echo $DATA | jq -r --arg e "${DASHBOARD}" ".[$e]")
+            DASHBOARD_FILE=$(echo $DATA | jq -r --arg e "${DASHBOARD}" '.[$e]')
             
             echo ${DASHBOARD}
             echo ${DASHBOARD_FILE}

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -190,7 +190,7 @@ jobs:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
           DASHBOARDS: ("datahub-status-dashboard" "datahub-deployment-dashboard")
         run: |
-          for DASHBOARD in ${DASHBOARDS[@])
+          for DASHBOARD in "${DASHBOARDS[@]}"
           do
             kubectl create configmap ${DASHBOARD} \
             --from-file=helm_deploy/monitoring/datahub-dashboard.json \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -188,9 +188,9 @@ jobs:
         id: update-grafana-dashboards
         env:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
-          DASHBOARDS: '["datahub-status-dashboard", "datahub-deployment-dashboard"]'
+          DASHBOARDS: ("datahub-status-dashboard" "datahub-deployment-dashboard")
         run: |
-          for DASHBOARD in fromJSON(${DASHBOARDS})
+          for DASHBOARD in ${DASHBOARDS[@])
           do
             kubectl create configmap ${DASHBOARD} \
             --from-file=helm_deploy/monitoring/datahub-dashboard.json \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -138,39 +138,39 @@ jobs:
           echo "APP_SHORT_HOST=${KUBE_NAMESPACE/data-platform-/}.${BASE_HOST}" >> $GITHUB_ENV
           echo "EXT_DNS_ID=${RELEASE_NAME}-datahub-frontend-${{ inputs.env }}-${KUBE_NAMESPACE}-green" >> $GITHUB_ENV
 
-      # - name: install datahub helm charts
-      #   shell: bash
-      #   id: upgrade-helm-datahub
-      #   env:
-      #     APP_SHORT_HOST: ${{ env.APP_SHORT_HOST }}
-      #     CHART_VERSION: ${{ inputs.datahub_helm_version }}
-      #     IRSA_SA: data-platform-${{ inputs.env }}
-      #     OPENSEARCH_PROXY_HOST: ${{ secrets.OPENSEARCH_PROXY_HOST }}
-      #     POSTGRES_CLIENT_HOST: ${{ secrets.postgres_client_host }}
-      #     POSTGRES_HOST: ${{ secrets.postgres_host }}
-      #     POSTGRES_URL: ${{ secrets.postgres_url }}
-      #     RELEASE_NAME: datahub
-      #     FRONTEND_FULLNAME: datahub-frontend-${{ inputs.env }}
-      #   # if many env-specific variables need setting, add --values files after 'base'
-      #   # e.g. `--values helm_deploy/values-${{ inputs.env }}.yaml \`
-      #   run: |
-      #     helm upgrade \
-      #     --install ${RELEASE_NAME} datahub/datahub \
-      #     --version ${CHART_VERSION} \
-      #     --atomic --timeout 10m0s \
-      #     --values helm_deploy/values-base.yaml \
-      #     --namespace ${{ secrets.kube_namespace }} \
-      #     --set datahub-frontend.fullnameOverride=${RELEASE_NAME}-${FRONTEND_FULLNAME} \
-      #     --set "datahub-frontend.oidcAuthentication.azureTenantId=${{ vars.TENANT_ID }}" \
-      #     --set "datahub-frontend.oidcAuthentication.clientId=${{ vars.CLIENT_ID }}" \
-      #     --set "datahub-frontend.ingress.tls[0].hosts[0]=${APP_SHORT_HOST}" \
-      #     --set "datahub-frontend.ingress.hosts[0].host=${APP_SHORT_HOST}" \
-      #     --set "datahub-frontend.ingress.annotations.external-dns\\.alpha\\.kubernetes\\.io/set-identifier=${EXT_DNS_ID}" \
-      #     --set acryl-datahub-actions.serviceAccount.name=${IRSA_SA} \
-      #     --set global.elasticsearch.host=${OPENSEARCH_PROXY_HOST} \
-      #     --set global.sql.datasource.host=${POSTGRES_HOST} \
-      #     --set global.sql.datasource.hostForpostgresqlClient=${POSTGRES_CLIENT_HOST} \
-      #     --set global.sql.datasource.url=${POSTGRES_URL}
+      - name: install datahub helm charts
+        shell: bash
+        id: upgrade-helm-datahub
+        env:
+          APP_SHORT_HOST: ${{ env.APP_SHORT_HOST }}
+          CHART_VERSION: ${{ inputs.datahub_helm_version }}
+          IRSA_SA: data-platform-${{ inputs.env }}
+          OPENSEARCH_PROXY_HOST: ${{ secrets.OPENSEARCH_PROXY_HOST }}
+          POSTGRES_CLIENT_HOST: ${{ secrets.postgres_client_host }}
+          POSTGRES_HOST: ${{ secrets.postgres_host }}
+          POSTGRES_URL: ${{ secrets.postgres_url }}
+          RELEASE_NAME: datahub
+          FRONTEND_FULLNAME: datahub-frontend-${{ inputs.env }}
+        # if many env-specific variables need setting, add --values files after 'base'
+        # e.g. `--values helm_deploy/values-${{ inputs.env }}.yaml \`
+        run: |
+          helm upgrade \
+          --install ${RELEASE_NAME} datahub/datahub \
+          --version ${CHART_VERSION} \
+          --atomic --timeout 10m0s \
+          --values helm_deploy/values-base.yaml \
+          --namespace ${{ secrets.kube_namespace }} \
+          --set datahub-frontend.fullnameOverride=${RELEASE_NAME}-${FRONTEND_FULLNAME} \
+          --set datahub-frontend.oidcAuthentication.azureTenantId=${{ vars.TENANT_ID }} \
+          --set datahub-frontend.oidcAuthentication.clientId=${{ vars.CLIENT_ID }} \
+          --set datahub-frontend.ingress.tls[0].hosts[0]=${APP_SHORT_HOST} \
+          --set datahub-frontend.ingress.hosts[0].host=${APP_SHORT_HOST} \
+          --set datahub-frontend.ingress.annotations.external-dns\\.alpha\\.kubernetes\\.io/set-identifier=${EXT_DNS_ID} \
+          --set acryl-datahub-actions.serviceAccount.name=${IRSA_SA} \
+          --set global.elasticsearch.host=${OPENSEARCH_PROXY_HOST} \
+          --set global.sql.datasource.host=${POSTGRES_HOST} \
+          --set global.sql.datasource.hostForpostgresqlClient=${POSTGRES_CLIENT_HOST} \
+          --set global.sql.datasource.url=${POSTGRES_URL}
 
       - name: allow CP prometheus scraping 
         if: ${{ inputs.env == 'dev' }}

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -182,20 +182,17 @@ jobs:
           envsubst < helm_deploy/monitoring/datahub-networkpolicy.yaml | 
             kubectl apply -f - --namespace=${KUBE_NAMESPACE}
 
-      - name: update grafana dashboard configmaps
+      - name: update grafana status dashboard configmap
         if: ${{ inputs.env == 'dev' }}
         shell: bash
-        id: update-grafana-dashboards
+        id: update-grafana-status-dashboard
         env:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
-          DASHBOARDS_JSON_STRING: '{"datahub-status-dashboard": "datahub-dashboard","datahub-deployment-dashboard": "datahub-deployment-dashboard"}'
+          DASHBOARD: "datahub-status-dashboard"
+          DASHBOARD_FILE: "datahub-dashboard.json"
         run: |
-          DASHBOARDS_JSON=$(jq -n -c "$DASHBOARDS_JSON_STRING")
-          echo $DASHBOARDS_JSON | jq -r 'to_entries | .[].key' | while read DASHBOARD; do
-            DASHBOARD_FILE=$(echo $DASHBOARDS_JSON | jq -r --arg e "${DASHBOARD}" '.[$e]')
-
             kubectl create configmap ${DASHBOARD} \
-            --from-file="helm_deploy/monitoring/${DASHBOARD_FILE}.json" \
+            --from-file="helm_deploy/monitoring/${DASHBOARD_FILE}" \
             --dry-run \
             --output yaml | 
               kubectl label -f- \
@@ -204,4 +201,23 @@ jobs:
               --local grafana_dashboard=${DASHBOARD} | 
               kubectl apply -f- \
               --namespace=${KUBE_NAMESPACE}
-          done
+
+      - name: update grafana deployment dashboard configmap
+        if: ${{ inputs.env == 'dev' }}
+        shell: bash
+        id: update-grafana-deployment-dashboard
+        env:
+          KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
+          DASHBOARD: "datahub-deployment-dashboard"
+          DASHBOARD_FILE: "datahub-deployment-dashboard.json"
+        run: |
+          kubectl create configmap ${DASHBOARD} \
+            --from-file="helm_deploy/monitoring/${DASHBOARD_FILE}" \
+            --dry-run \
+            --output yaml | 
+              kubectl label -f- \
+              --dry-run \
+              --output yaml \
+              --local grafana_dashboard=${DASHBOARD} | 
+              kubectl apply -f- \
+              --namespace=${KUBE_NAMESPACE}

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -188,9 +188,9 @@ jobs:
         id: update-grafana-dashboards
         env:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
-          DASHBOARDS: ("datahub-status-dashboard" "datahub-deployment-dashboard")
+          DASHBOARDS: "datahub-status-dashboard datahub-deployment-dashboard"
         run: |
-          DASHBOARD_NAMES="${DASHBOARDS}"
+          read -a DASHBOARD_NAMES <<< "${DASHBOARDS}"
           for DASHBOARD in "${DASHBOARD_NAMES[@]}"
           do
             echo ${DASHBOARD}

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -192,6 +192,7 @@ jobs:
         run: |
           for DASHBOARD in "${DASHBOARDS[@]}"
           do
+            echo ${DASHBOARD}
             kubectl create configmap ${DASHBOARD} \
             --from-file=helm_deploy/monitoring/datahub-dashboard.json \
             --dry-run \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -138,39 +138,39 @@ jobs:
           echo "APP_SHORT_HOST=${KUBE_NAMESPACE/data-platform-/}.${BASE_HOST}" >> $GITHUB_ENV
           echo "EXT_DNS_ID=${RELEASE_NAME}-datahub-frontend-${{ inputs.env }}-${KUBE_NAMESPACE}-green" >> $GITHUB_ENV
 
-      - name: install datahub helm charts
-        shell: bash
-        id: upgrade-helm-datahub
-        env:
-          APP_SHORT_HOST: ${{ env.APP_SHORT_HOST }}
-          CHART_VERSION: ${{ inputs.datahub_helm_version }}
-          IRSA_SA: data-platform-${{ inputs.env }}
-          OPENSEARCH_PROXY_HOST: ${{ secrets.OPENSEARCH_PROXY_HOST }}
-          POSTGRES_CLIENT_HOST: ${{ secrets.postgres_client_host }}
-          POSTGRES_HOST: ${{ secrets.postgres_host }}
-          POSTGRES_URL: ${{ secrets.postgres_url }}
-          RELEASE_NAME: datahub
-          FRONTEND_FULLNAME: datahub-frontend-${{ inputs.env }}
-        # if many env-specific variables need setting, add --values files after 'base'
-        # e.g. `--values helm_deploy/values-${{ inputs.env }}.yaml \`
-        run: |
-          helm upgrade \
-          --install ${RELEASE_NAME} datahub/datahub \
-          --version ${CHART_VERSION} \
-          --atomic --timeout 10m0s \
-          --values helm_deploy/values-base.yaml \
-          --namespace ${{ secrets.kube_namespace }} \
-          --set datahub-frontend.fullnameOverride=${RELEASE_NAME}-${FRONTEND_FULLNAME} \
-          --set "datahub-frontend.oidcAuthentication.azureTenantId=${{ vars.TENANT_ID }}" \
-          --set "datahub-frontend.oidcAuthentication.clientId=${{ vars.CLIENT_ID }}" \
-          --set "datahub-frontend.ingress.tls[0].hosts[0]=${APP_SHORT_HOST}" \
-          --set "datahub-frontend.ingress.hosts[0].host=${APP_SHORT_HOST}" \
-          --set "datahub-frontend.ingress.annotations.external-dns\\.alpha\\.kubernetes\\.io/set-identifier=${EXT_DNS_ID}" \
-          --set acryl-datahub-actions.serviceAccount.name=${IRSA_SA} \
-          --set global.elasticsearch.host=${OPENSEARCH_PROXY_HOST} \
-          --set global.sql.datasource.host=${POSTGRES_HOST} \
-          --set global.sql.datasource.hostForpostgresqlClient=${POSTGRES_CLIENT_HOST} \
-          --set global.sql.datasource.url=${POSTGRES_URL}
+      # - name: install datahub helm charts
+      #   shell: bash
+      #   id: upgrade-helm-datahub
+      #   env:
+      #     APP_SHORT_HOST: ${{ env.APP_SHORT_HOST }}
+      #     CHART_VERSION: ${{ inputs.datahub_helm_version }}
+      #     IRSA_SA: data-platform-${{ inputs.env }}
+      #     OPENSEARCH_PROXY_HOST: ${{ secrets.OPENSEARCH_PROXY_HOST }}
+      #     POSTGRES_CLIENT_HOST: ${{ secrets.postgres_client_host }}
+      #     POSTGRES_HOST: ${{ secrets.postgres_host }}
+      #     POSTGRES_URL: ${{ secrets.postgres_url }}
+      #     RELEASE_NAME: datahub
+      #     FRONTEND_FULLNAME: datahub-frontend-${{ inputs.env }}
+      #   # if many env-specific variables need setting, add --values files after 'base'
+      #   # e.g. `--values helm_deploy/values-${{ inputs.env }}.yaml \`
+      #   run: |
+      #     helm upgrade \
+      #     --install ${RELEASE_NAME} datahub/datahub \
+      #     --version ${CHART_VERSION} \
+      #     --atomic --timeout 10m0s \
+      #     --values helm_deploy/values-base.yaml \
+      #     --namespace ${{ secrets.kube_namespace }} \
+      #     --set datahub-frontend.fullnameOverride=${RELEASE_NAME}-${FRONTEND_FULLNAME} \
+      #     --set "datahub-frontend.oidcAuthentication.azureTenantId=${{ vars.TENANT_ID }}" \
+      #     --set "datahub-frontend.oidcAuthentication.clientId=${{ vars.CLIENT_ID }}" \
+      #     --set "datahub-frontend.ingress.tls[0].hosts[0]=${APP_SHORT_HOST}" \
+      #     --set "datahub-frontend.ingress.hosts[0].host=${APP_SHORT_HOST}" \
+      #     --set "datahub-frontend.ingress.annotations.external-dns\\.alpha\\.kubernetes\\.io/set-identifier=${EXT_DNS_ID}" \
+      #     --set acryl-datahub-actions.serviceAccount.name=${IRSA_SA} \
+      #     --set global.elasticsearch.host=${OPENSEARCH_PROXY_HOST} \
+      #     --set global.sql.datasource.host=${POSTGRES_HOST} \
+      #     --set global.sql.datasource.hostForpostgresqlClient=${POSTGRES_CLIENT_HOST} \
+      #     --set global.sql.datasource.url=${POSTGRES_URL}
 
       - name: allow CP prometheus scraping 
         if: ${{ inputs.env == 'dev' }}
@@ -188,9 +188,9 @@ jobs:
         id: update-grafana-dashboards
         env:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
-          DASHBOARDS: ("datahub-status-dashboard", "datahub-deployment-dashboard")
+          DASHBOARDS: ("datahub-status-dashboard" "datahub-deployment-dashboard")
         run: |
-          for DASHBOARD in $DASHBOARDS
+          for DASHBOARD in ${DASHBOARDS}
           do
             kubectl create configmap ${DASHBOARD} \
             --from-file=helm_deploy/monitoring/datahub-dashboard.json \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -191,7 +191,7 @@ jobs:
           DASHBOARDS_JSON_STRING: '{"datahub-status-dashboard": "datahub-dashboard","datahub-deployment-dashboard": "datahub-deployment-dashboard"}'
         run: |
           DASHBOARDS_JSON=$(jq -n -c "$DASHBOARDS_JSON_STRING")
-          echo $DASHBOARDS_JSON | jq 'to_entries | .[].key' | while read DASHBOARD; do
+          echo $DASHBOARDS_JSON | jq -r 'to_entries | .[].key' | while read DASHBOARD; do
             DASHBOARD_FILE=$(echo $DATA | jq -r ".[$DASHBOARD]")
             
             kubectl create configmap ${DASHBOARD} \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -194,6 +194,11 @@ jobs:
           echo $DASHBOARDS_JSON | jq -r 'to_entries | .[].key' | while read DASHBOARD; do
             DASHBOARD_FILE=$(echo $DATA | jq -r --arg e "${DASHBOARD}" ".[$e]")
             
+            echo ${DASHBOARD}
+            echo ${DASHBOARD_FILE}
+            echo grafana_dashboard=${DASHBOARD}
+            echo "helm_deploy/monitoring/${DASHBOARD_FILE}.json"
+
             kubectl create configmap ${DASHBOARD} \
             --from-file="helm_deploy/monitoring/${DASHBOARD_FILE}.json" \
             --dry-run \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -192,7 +192,7 @@ jobs:
         run: |
           DASHBOARDS_JSON=$(jq -n -c "$DASHBOARDS_JSON_STRING")
           echo $DASHBOARDS_JSON | jq -r 'to_entries | .[].key' | while read DASHBOARD; do
-            DASHBOARD_FILE=$(echo $DATA | jq -r ".[$DASHBOARD]")
+            DASHBOARD_FILE=$(echo $DATA | jq -r --arg e "${DASHBOARD}" ".[$e]")
             
             kubectl create configmap ${DASHBOARD} \
             --from-file="helm_deploy/monitoring/${DASHBOARD_FILE}.json" \

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -190,6 +190,7 @@ jobs:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
           DASHBOARDS: ("datahub-status-dashboard" "datahub-deployment-dashboard")
         run: |
+          DASHBOARDS="${DASHBOARDS[@]}"
           for DASHBOARD in "${DASHBOARDS[@]}"
           do
             echo ${DASHBOARD}

--- a/helm_deploy/monitoring/datahub-deployment-dashboard.json
+++ b/helm_deploy/monitoring/datahub-deployment-dashboard.json
@@ -1,0 +1,2685 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      },
+      {
+        "actionPrefix": "",
+        "alarmNamePrefix": "",
+        "alias": "",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "dimensions": {},
+        "enable": true,
+        "expr": "kube_pod_created{namespace=\"$namespace\", pod=~\"$service-.*\"} * 1000",
+        "expression": "",
+        "hide": false,
+        "iconColor": "#3274D9",
+        "id": "",
+        "matchExact": true,
+        "metricName": "",
+        "name": "service pod creation",
+        "namespace": "",
+        "period": "",
+        "prefixMatching": false,
+        "region": "default",
+        "showIn": 0,
+        "statistic": "Average",
+        "textFormat": "",
+        "titleFormat": "{{ pod }}",
+        "useValueForTime": true
+      }
+    ]
+  },
+  "description": "High level application HTTP request and resource usage information.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 163,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 39,
+      "panels": [],
+      "title": "Resource Usage",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "Limit": "#bf1b00",
+        "Limit (hard limit)": "#bf1b00",
+        "Requested (soft limit)": "#f2c96d"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 450,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.3.3",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "max(container_memory_usage_bytes{namespace='$namespace',container!=\"POD\",container!=\"\"}) by (container)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ container }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "avg(kube_pod_container_resource_requests_memory_bytes{namespace='$namespace'})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Requested (soft limit)",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "avg(kube_pod_container_resource_limits_memory_bytes{namespace='$namespace'})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Limit (hard limit)",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Memory usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:534",
+          "format": "bytes",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:535",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {
+        "Limit": "#bf1b00",
+        "Requested (soft limit)": "#f2c96d"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 450,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.3.3",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "max by (container)(increase(container_cpu_usage_seconds_total{namespace='$namespace',container!=\"POD\",container!=\"\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "avg(kube_pod_container_resource_requests_cpu_cores{namespace='$namespace'})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Requested (soft limit)",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "avg(kube_pod_container_resource_limits_cpu_cores{namespace='$namespace'})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Limit (hard limit)",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "CPU usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:691",
+          "format": "percent",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:692",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 38,
+      "panels": [],
+      "title": "Pod status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The number of pod replicas for the service.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "datahub-datahub-frontend-dev",
+                  "datahub-datahub-gms",
+                  "prerequisites-kafka"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "count(\n  label_replace(kube_pod_info{namespace=\"$namespace\"}, \"pod\", \"$1\", \"created_by_name\", \"(.*)-\\\\w+\")\n) by (pod)",
+          "interval": "",
+          "legendFormat": "{{ created_by_name }}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Pod Replicas",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the count of pod/container restart events observed.  This will show \"CrashLooping\" error events.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (pod) (increase(kube_pod_container_status_restarts_total{namespace=\"$namespace\"}[10m])) > 0",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{ pod }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Restarts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the count of pods in an \"non-ready\" state.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (pod) (\n  kube_pod_status_phase{namespace=\"$namespace\", phase=~\"Pending|Unknown\"}\n) > 0",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{ pod }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Non-Ready Pods",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 37,
+      "panels": [],
+      "title": "Resource usage (in-depth)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "CPU usage in relation to the requested cpu for the container.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Percentage",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "datahub-frontend",
+                  "datahub-gms"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "avg(irate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container!=\"POD\", container=~\".+\"}[1m])) by (container)\n/ \navg(kube_pod_container_resource_requests{resource=\"cpu\", namespace=\"$namespace\"}) by (container)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requested CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Average recorded CPU usage for each type container within the pods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "datahub-frontend",
+                  "datahub-gms"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "avg(\n  irate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container!=\"POD\", container=~\".+\"}[1m])\n) by (container)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Actual CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Memory usage in relation to the requested memory for the container.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Percentage",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "datahub-frontend",
+                  "datahub-gms"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 27
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "avg(irate(container_memory_usage_bytes{namespace=\"$namespace\", container!=\"POD\", container=~\".+\"}[1m])) by (container)\n/ \navg(kube_pod_container_resource_requests{resource=\"memory\", namespace=\"$namespace\"}) by (container)\n* 100",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requested Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Average recorded memory usage for a single type of container within the pods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "datahub-frontend",
+                  "datahub-gms"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 27
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "avg(\n  irate(container_memory_usage_bytes{namespace=\"$namespace\", container!=\"POD\", container=~\".+\"}[1m])\n) by (container)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Actual Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 12,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Frontend Stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The number of HTTP requests by status",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Number of requests",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 20,
+        "x": 0,
+        "y": 36
+      },
+      "id": 15,
+      "interval": "1m",
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(\n  increase(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__interval])\n) by (status) != 0",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The total number of requests served in the selected time period.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 36
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(increase(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[${__range_s}s]))",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Served",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The mean response time (p100 - all requests) over the selected timeframe.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 39
+      },
+      "id": 28,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  1,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[${__range_s}s])\n  ) by (le)\n) > 0",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mean Response Time (p100)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The mean response time (p95 - the 95th percentile of requests) over the selected timeframe.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 20,
+        "y": 42
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.95,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[${__range_s}s])\n  ) by (le)\n) > 0",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mean Response Time (p95)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The mean response time (p50 - the 50th percentile requests) over the selected timeframe.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 20,
+        "y": 44
+      },
+      "id": 33,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.5,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[${__range_s}s])\n  ) by (le)\n) > 0",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mean Response Time (p50)",
+      "type": "stat"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#FADE2A",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateSpectral",
+        "exponent": 0.2,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 18,
+      "legend": {
+        "show": true
+      },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#FADE2A",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "10.3.3",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum by (le)(\n  increase(\n    nginx_ingress_controller_request_duration_seconds_bucket{\n      exported_namespace =~ \"$namespace\",\n      ingress=~\"$service|$service-.+\",\n    }[1m]\n  )\n)",
+          "format": "heatmap",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Frontend request durations",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketSize": "",
+      "yAxis": {
+        "format": "s",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Recorded request duration from the ingress controllers in percentiles.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.5,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__rate_interval])\n  ) by (le)\n)",
+          "interval": "",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  0.95,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__rate_interval])\n  ) by (le)\n)",
+          "interval": "",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(\n  1,\n  max(\n    irate(nginx_ingress_controller_request_duration_seconds_bucket{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__rate_interval])\n  ) by (le)\n)",
+          "interval": "",
+          "legendFormat": "p100",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The percentage of HTTP responses that are non-error codes vs error codes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Percentage",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 54
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\", status!~\"5.*|499\"}[$__rate_interval]))\n/ \nsum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__rate_interval]))\n* 100",
+          "interval": "",
+          "legendFormat": "Request Success Rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Availability",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The percentage of all HTTP requests that result in a 5xx status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Percentage",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 54
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\", status=\"500\"}[$__rate_interval])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__rate_interval]))\n* 100",
+          "interval": "",
+          "legendFormat": "500",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\", status=\"501\"}[$__rate_interval])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__rate_interval]))\n* 100",
+          "interval": "",
+          "legendFormat": "501",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\", status=\"502\"}[$__rate_interval])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__rate_interval]))\n* 100",
+          "interval": "",
+          "legendFormat": "502",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\", status=\"503\"}[$__rate_interval])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__rate_interval]))\n* 100",
+          "interval": "",
+          "legendFormat": "503",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\", status=\"504\"}[$__rate_interval])) \n/ \nsum(irate(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\"}[$__rate_interval]))\n* 100",
+          "interval": "",
+          "legendFormat": "504",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the number of blocked requests at the ingress level.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 54
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(\n  increase(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\", status=\"429\"}[$__rate_interval])\n)\nor\nvector(0)",
+          "interval": "1m",
+          "legendFormat": "Rate Limited Reqs",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(\n  increase(nginx_ingress_controller_requests{ingress=~\"$service|$service-.+\", exported_namespace=\"$namespace\", status=\"406\"}[$__rate_interval])\n)\nor\nvector(0)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "Mod Security Blocked Reqs",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Blocked Requests",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 35,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Network operations",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The amount of data being sent to and from the pods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Receive"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum(irate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"$service-.+\"}[2m]))",
+          "interval": "",
+          "legendFormat": "Receive",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum(irate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"$service-.+\"}[2m]))",
+          "interval": "",
+          "legendFormat": "Transmit",
+          "refId": "C"
+        }
+      ],
+      "title": "Frontend Network I/O",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The amount of data being sent to and from the pods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Receive"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 63
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "-sum by (pod)(irate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"$service-.+\"}[2m]))",
+          "interval": "",
+          "legendFormat": "Receive datahub-frontend",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "-sum by (pod)(irate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\".+gms-.+\"}[2m]))",
+          "interval": "",
+          "legendFormat": "Receive datahub-gms",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "-sum by (pod)(irate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"opensearch-proxy-.+\"}[2m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Receive opensearch-proxy",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod)(irate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"$service-.+\"}[2m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Transmit datahub-frontend",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod)(irate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\".+-gms-.+\"}[2m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Transmit datahub-gms",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod)(irate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"opensearch-proxy.+\"}[2m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Transmit opensearch-proxy",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Network I/O",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "kubernetes",
+    "nginx-ingress"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "data-platform-datahub-catalogue-dev",
+          "value": "data-platform-datahub-catalogue-dev"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(nginx_ingress_controller_requests{}, exported_namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(nginx_ingress_controller_requests{}, exported_namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/^data-platform-datahub-catalogue-/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "datahub-datahub-frontend-dev",
+          "value": "datahub-datahub-frontend-dev"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(nginx_ingress_controller_requests{exported_namespace=\"$namespace\"}, exported_service)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(nginx_ingress_controller_requests{exported_namespace=\"$namespace\"}, exported_service)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "Prometheus",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "DataHub deployment status dashboard",
+  "uid": "2yTpJtUU4G8iGuqPdEkG",
+  "version": 10,
+  "weekStart": ""
+}


### PR DESCRIPTION
Deploy a [monitoring dashboard to check the status of the DataHub deployments](https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard?orgId=1&var-namespace=data-platform-datahub-catalogue-dev&var-service=datahub-datahub-frontend-dev&var-DS_PROMETHEUS=prometheus). Primary role is to get an overview of the functioning of the pods and services.

Dashboards are now only refreshed on a deploy to dev