### PR TITLE
add PrometheusRules for DataHub

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -133,10 +133,13 @@ jobs:
           KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
           BASE_HOST: apps.live.cloud-platform.service.justice.gov.uk
           RELEASE_NAME: datahub
+          POSTGRES_CLIENT_HOST: ${{ secrets.postgres_client_host }}
         run: |-
           echo "BASE_HOST=${BASE_HOST}" >> $GITHUB_ENV 
           echo "APP_SHORT_HOST=${KUBE_NAMESPACE/data-platform-/}.${BASE_HOST}" >> $GITHUB_ENV
           echo "EXT_DNS_ID=${RELEASE_NAME}-datahub-frontend-${{ inputs.env }}-${KUBE_NAMESPACE}-green" >> $GITHUB_ENV
+          echo "OPENSEARCH_DOMAIN=$(echo ${OPENSEARCH_PROXY_HOST} | sed -e 's/[.].*$//' -e 's/opensearch-proxy-service-//')" >> $GITHUB_ENV
+          echo "RDS_DOMAIN=$(echo ${POSTGRES_CLIENT_HOST/[.]*/})" >> $GITHUB_ENV
 
       - name: install datahub helm charts
         shell: bash
@@ -181,6 +184,19 @@ jobs:
         run: |
           envsubst < helm_deploy/monitoring/datahub-networkpolicy.yaml | 
             kubectl apply -f - --namespace=${KUBE_NAMESPACE}
+
+      - name: apply PrometheusRule alerts
+        shell: bash
+        id: apply-prom-rule-alerts
+        env:
+          KUBE_NAMESPACE: ${{ secrets.kube_namespace }}
+          ENV: ${{ inputs.env }}
+        run: |
+          for filename in ./helm_deploy/monitoring/prom_alerts/prometheus-*-alert.yaml; do 
+            [ -e "$filename" ] || continue 
+            envsubst < "$filename" | 
+              kubectl apply -f - --namespace=${KUBE_NAMESPACE}
+          done
 
       - name: update grafana status dashboard configmap
         if: ${{ inputs.env == 'dev' }}

--- a/helm_deploy/monitoring/prom_alerts/prometheus-aws-resources-alert.yaml
+++ b/helm_deploy/monitoring/prom_alerts/prometheus-aws-resources-alert.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: ${KUBE_NAMESPACE}-alerting-ingress
+  name: ${KUBE_NAMESPACE}-alerting-aws-resources
   labels:
     role: alert-rules
     prometheus: cloud-platform

--- a/helm_deploy/monitoring/prom_alerts/prometheus-aws-resources-alert.yaml
+++ b/helm_deploy/monitoring/prom_alerts/prometheus-aws-resources-alert.yaml
@@ -1,0 +1,94 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ${KUBE_NAMESPACE}-alerting-ingress
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+    - name: application-rules
+      rules:
+        - alert: RDSLowStorage
+          annotations:
+            message: "[{{ $labels.dbinstance_identifier }}] RDS storage below 5GB."
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: aws_rds_free_storage_space_average{dbinstance_identifier=${RDS_DOMAIN}} offset 10m < 5000000000
+          for: 5m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: RDSCPUUtilization
+          annotations:
+            message: "[{{ $labels.dbinstance_identifier }}] RDS CPU utilization above 80%."
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: aws_rds_cpuutilization_average{dbinstance_identifier=${RDS_DOMAIN}} > 80
+          for: 15m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: RDSMaxConnections
+          annotations:
+            message: "[{{ $labels.dbinstance_identifier }}] RDS connections above 80% of maximum."
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: aws_rds_database_connections_maximum{dbinstance_identifier=${RDS_DOMAIN}} > 1044
+          for: 15m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: ElasticSearchClusterRedStatus
+          annotations:
+            message: "[{{ $labels.domain_name }}] At least one primary ElasticSearch shard and its replicas are not allocated to a node."
+            runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html#aes-handling-errors-red-cluster-status
+          expr: aws_es_cluster_status_red_maximum{domain_name=${OPENSEARCH_DOMAIN}} >= 1
+          for: 1m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: ElasticSearchClusterYellowStatus
+          annotations:
+            message: "[{{ $labels.domain_name }}] At least one ElasticSearch replica shard is not allocated to a node"
+            runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html#aes-handling-errors-yellow-cluster-status
+          expr: aws_es_cluster_status_yellow_maximum{domain_name=${OPENSEARCH_DOMAIN}} >= 1
+          for: 6m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: ElasticSearchClusterFreeStorageSpace
+          annotations:
+            message: "[{{ $labels.domain_name }}] A node in the ElasticSearch cluster is down to 3 GiB of free storage space"
+            runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html#aes-handling-errors-watermark
+          expr: aws_es_free_storage_space_maximum{domain_name=${OPENSEARCH_DOMAIN}} <= 3072
+          for: 1m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: ElasticSearchClusterIndexWritesBlocked
+          annotations:
+            message: "[{{ $labels.domain_name }}] The ElasticSearch cluster is blocking write requests"
+            runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html#troubleshooting-cluster-block
+          expr: aws_es_cluster_index_writes_blocked_maximum{domain_name=${OPENSEARCH_DOMAIN}} >= 1
+          for: 5m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: ElasticSearchClusterAutomatedSnapshotFailure
+          annotations:
+            message: "[{{ $labels.domain_name }}] An automated snapshot for the ElasticSearch cluster failed"
+            runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html
+          expr: aws_es_automated_snapshot_failure_maximum{domain_name=${OPENSEARCH_DOMAIN}} >= 1
+          for: 1m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: ElasticSearchClusterJVMMemoryPressure
+          annotations:
+            message: "[{{ $labels.domain_name }}] The ElasticSearch cluster could encounter out of memory errors if usage increases"
+            runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html
+          expr: aws_es_jvmmemory_pressure_maximum{domain_name=${OPENSEARCH_DOMAIN}} >= 80
+          for: 15m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: ElasticSearchClusterCPUUtilization
+          annotations:
+            message: "[{{ $labels.domain_name }}] The ElasticSearch cluster has sustained high CPU usage"
+            runbook_url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html
+          expr: aws_es_cpuutilization_maximum{domain_name=${OPENSEARCH_DOMAIN}} >= 80
+          for: 15m
+          labels:
+            severity: DataHub-${ENV}

--- a/helm_deploy/monitoring/prom_alerts/prometheus-deployment-alert.yaml
+++ b/helm_deploy/monitoring/prom_alerts/prometheus-deployment-alert.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: ${KUBE_NAMESPACE}-alerting-ingress
+  name: ${KUBE_NAMESPACE}-alerting-deployment
   labels:
     role: alert-rules
     prometheus: cloud-platform

--- a/helm_deploy/monitoring/prom_alerts/prometheus-ingress-alert.yaml
+++ b/helm_deploy/monitoring/prom_alerts/prometheus-ingress-alert.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ${KUBE_NAMESPACE}-alerting-ingress
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+    - name: application-rules
+      rules:
+        - alert: ModSecurityBlocking
+          annotations:
+            message: modsecurity is blocking ingress {{ $labels.ingress }}
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: |-
+            avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace=~"${KUBE_NAMESPACE}", status="406"}[1m]) * 60 > 0) by (ingress)
+          for: 1m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: ErrorResponses
+          annotations:
+            message: ingress {{ $labels.ingress }} is serving 5XX responses
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: |-
+            avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace=~"${KUBE_NAMESPACE}", status=~"5.*"}[1m]) * 60 > 0) by (ingress)
+          for: 1m
+          labels:
+            severity: DataHub-${ENV}

--- a/helm_deploy/monitoring/prom_alerts/prometheus-pod-deployment-alert.yaml
+++ b/helm_deploy/monitoring/prom_alerts/prometheus-pod-deployment-alert.yaml
@@ -1,0 +1,60 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ${KUBE_NAMESPACE}-alerting-ingress
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+    - name: application-rules
+      rules:
+        - alert: KubeDeploymentGenerationMismatch
+          annotations:
+            message:
+              Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+              }} does not match, this indicates that the Deployment has failed but has
+              not been rolled back.
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: |-
+            kube_deployment_status_observed_generation{namespace=~"${KUBE_NAMESPACE}", job="kube-state-metrics"}
+              !=
+            kube_deployment_metadata_generation{namespace=~"${KUBE_NAMESPACE}", job="kube-state-metrics"}
+          for: 15m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: KubeDeploymentReplicasMismatch
+          annotations:
+            message:
+              Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+              matched the expected number of replicas for longer than an hour.
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: |-
+            kube_deployment_spec_replicas{namespace=~"${KUBE_NAMESPACE}", job="kube-state-metrics"}
+              !=
+            kube_deployment_status_replicas_available{namespace=~"${KUBE_NAMESPACE}", job="kube-state-metrics"}
+          for: 1h
+          labels:
+            severity: DataHub-${ENV}
+        - alert: KubeCronJobRunning
+          annotations:
+            message:
+              CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+              than 1h to complete.
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: time() - kube_cronjob_next_schedule_time{namespace=~"${KUBE_NAMESPACE}"} > 3600
+          for: 1h
+          labels:
+            severity: DataHub-${ENV}
+        - alert: KubeJobFailed
+          annotations:
+            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: kube_job_status_failed{namespace=~"${KUBE_NAMESPACE}"}  > 0
+          for: 1h
+          labels:
+            severity: DataHub-${ENV}

--- a/helm_deploy/monitoring/prom_alerts/prometheus-pod-status-alert.yaml
+++ b/helm_deploy/monitoring/prom_alerts/prometheus-pod-status-alert.yaml
@@ -1,0 +1,84 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ${KUBE_NAMESPACE}-alerting-status
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+    - name: application-rules
+      rules:
+        - alert: OOMKiller
+          annotations:
+            message: :alert:Service '{{"{{" }} $labels.pod {{"}}"}}'
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: >-
+            (kube_pod_container_status_restarts_total{job="kube-state-metrics",namespace="${KUBE_NAMESPACE}"} 
+            - kube_pod_container_status_restarts_total{job="kube-state-metrics",namespace="${KUBE_NAMESPACE}"} offset 10m >= 1) 
+            and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{job="kube-state-metrics",namespace="${KUBE_NAMESPACE}",reason="OOMKilled"}[10m]) == 1
+          labels:
+            severity: DataHub-${ENV}
+        - alert: TooManyContainerRestarts
+          annotations:
+            message: :alert:Service '{{"{{" }} $labels.pod {{"}}"}}' was restarted many times
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: sum(increase(kube_pod_container_status_restarts_total{namespace="${KUBE_NAMESPACE}",pod_template_hash=""}[15m])) by (pod,namespace,container) > 10
+          for: 0m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: CrashLoopBackOff
+          annotations:
+            message: :alert:Service '{{"{{" }} $labels.pod {{"}}"}}' CrashLoopBackOff
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics",namespace="${KUBE_NAMESPACE}",phase=~"CrashLoopBackOff"}) > 0
+          for: 0m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: PodNotReadyKube
+          annotations:
+            message: :alert:Service '{{"{{" }} $labels.pod {{"}}"}}' has been in a non-ready state for more than 15 minutes
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: sum by(namespace,pod)(kube_pod_status_phase{job="kube-state-metrics",namespace="${KUBE_NAMESPACE}",phase=~"Pending|Unknown"}) > 0
+          for: 15m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: ContainerRestartAlert
+          annotations:
+            message: :alert:Service '{{"{{" }} $labels.pod {{"}}"}}' has restarted.
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: (sum(increase(kube_pod_container_status_restarts_total{namespace="${KUBE_NAMESPACE}"}[10m])) by (container, namespace)) > 0
+          for: 5m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: KubePodCrashLooping
+          annotations:
+            message:
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+              }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr:
+            rate(kube_pod_container_status_restarts_total{namespace=~"${KUBE_NAMESPACE}", job="kube-state-metrics"}[15m])
+            * 60 * 5 > 0
+          for: 1h
+          labels:
+            severity: DataHub-${ENV}
+        - alert: KubePodNotReady
+          annotations:
+            message:
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+              state for longer than an hour.
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr:
+            sum by (namespace, pod) (kube_pod_status_phase{namespace=~"${KUBE_NAMESPACE}", job="kube-state-metrics",
+            phase=~"Pending|Unknown"}) > 0
+          for: 1h
+          labels:
+            severity: DataHub-${ENV}

--- a/helm_deploy/monitoring/prom_alerts/prometheus-pod-status-alert.yaml
+++ b/helm_deploy/monitoring/prom_alerts/prometheus-pod-status-alert.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: ${KUBE_NAMESPACE}-alerting-status
+  name: ${KUBE_NAMESPACE}-alerting-pod-status
   labels:
     role: alert-rules
     prometheus: cloud-platform

--- a/helm_deploy/monitoring/prom_alerts/prometheus-resource-alert.yaml
+++ b/helm_deploy/monitoring/prom_alerts/prometheus-resource-alert.yaml
@@ -1,0 +1,56 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ${KUBE_NAMESPACE}-alerting-resource
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+    - name: application-rules
+      rules:
+        - alert: GMSCpuUsageHigh
+          annotations:
+            message: :warning:Service '{{"{{" }} $labels.container {{"}}"}}' cpu usage above threshold of 60%.
+          expr: >-
+            (sum(rate(container_cpu_usage_seconds_total{namespace="data-platform-datahub-catalogue-dev", container=~".+gms"}[5m])) 
+            / sum(kube_pod_container_resource_limits{namespace="data-platform-datahub-catalogue-dev", container=~".+gms", unit="core"})) * 100  
+            > 90
+          for: 1m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: GMSMemUsageHigh
+          annotations:
+            message: :warning:Service '{{"{{" }} $labels.container {{"}}"}}' memory usage above 80%.
+          expr: >-
+            ((( sum(container_memory_working_set_bytes{container=~".+gms.+", namespace="${KUBE_NAMESPACE}"}) by (namespace,container,pod)  
+            / sum(kube_pod_container_resource_limits{container=~".+gms.+",namespace="${KUBE_NAMESPACE}",unit="byte"}) by (namespace,container,pod) ) * 100 ) < +Inf )
+             > 80
+          for: 1m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: HighPersistantVolumeUsage
+          annotations:
+            message: :warning:Service '{{"{{" }} $labels.container {{"}}"}}' Persistent volume is using more than 90%
+          expr: >-
+            ((((sum(kubelet_volume_stats_used_bytes{namespace="${KUBE_NAMESPACE}"}) by (namespace,persistentvolumeclaim)) 
+            / (sum(kubelet_volume_stats_capacity_bytes{namespace="${KUBE_NAMESPACE}"}) by (namespace,persistentvolumeclaim)))*100) < +Inf ) 
+            > 90
+          for: 5m
+          labels:
+            severity: DataHub-${ENV}
+        - alert: KubeQuotaExceeded
+          annotations:
+            message:
+              Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
+              }}% of its {{ $labels.resource }} quota.
+            runbook_url: https://runbooks.data-catalogue.service.justice.gov.uk/
+            dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/2yTpJtUU4G8iGuqPdEkG/datahub-deployment-status-dashboard
+          expr: |-
+            100 * kube_resourcequota{namespace=~"${KUBE_NAMESPACE}", job="kube-state-metrics", type="used"}
+              / ignoring(instance, job, type)
+            (kube_resourcequota{namespace=~"${KUBE_NAMESPACE}", job="kube-state-metrics", type="hard"} > 0)
+              > 90
+          for: 15m
+          labels:
+            severity: DataHub-${ENV}


### PR DESCRIPTION
Add PrometheusRule alerts for the DataHub namespaces in Cloud Platform, pointing at the aws resources (rds, opensearch), resource usage metrics (for the `datahub-gms` pod), deployment metrics, pod status metrics (out of memory, crashloop backoff, frequent restarts), ingress metrics (modsecurity blocking events, servicing error responses).

Opensearch metrics may not be suffificient, as during a recent bottleneck event, Opensearch was unresponsive but Prometheus metrics were absent during the period of downtime. 