### PR TITLE
add Slack security alerts for DataHub

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,6 +7,8 @@ on:
       - "scripts/**.py"
       - "tests/**.py"
   push:
+    branches:
+      - main
     paths:
       - "scripts/**.py"
       - "tests/**.py"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,4 +26,4 @@ jobs:
 
       - name: run unit tests
         id: python-tests
-        run: poetry run pytest tests/
+        run: pytest tests/

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,29 @@
+name: Run Python Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/**.py"
+      - "tests/**.py"
+  push:
+    paths:
+      - "scripts/**.py"
+      - "tests/**.py"
+      
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: pip install semantic-version pytest
+
+      - name: run unit tests
+        id: python-tests
+        run: poetry run pytest tests/

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,7 @@ on:
       - "tests/**.py"
       
 jobs:
-  unit:
+  python-unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -29,11 +29,11 @@ jobs:
           | head -n 1)
           echo "last_run_date=${LAST_RUN_DATE}" >> "${GITHUB_OUTPUT}"
 
-      - name: Read minimal version from values.yaml
-        id: read_minimal_version
+      - name: Read current version from values.yaml
+        id: read_current_version
         run: |
-          MINIMAL_VERSION=$(python -c "import yaml; print(yaml.safe_load(open('helm_deploy/values.yaml'))['global']['datahub']['version'])")
-          echo "minimal_version=${MINIMAL_VERSION}" >> "${GITHUB_OUTPUT}"
+          CURRENT_VERSION=$(python -c "import yaml; print(yaml.safe_load(open('helm_deploy/values.yaml'))['global']['datahub']['version'])")
+          echo "current_version=${CURRENT_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -46,7 +46,7 @@ jobs:
       - name: Filter advisories
         id: filter_advisories
         run: python scripts/filter_advisories.py \
-          "${{ steps.read_minimal_version.outputs.minimal_version }}" \
+          "${{ steps.read_current_version.outputs.current_version }}" \
           "${{ steps.get_last_run_date.outputs.last_run_date }}"
           
       - name: Send advisories to Slack

--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -1,0 +1,59 @@
+name: Security Advisory Alert
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs every day at midnight
+  workflow_dispatch:
+
+jobs:
+  check-security-advisories:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch security advisories
+        run: |
+          gh api -H "Accept: application/vnd.github+json" /repos/datahub-project/datahub/security-advisories > advisories.json
+
+      - name: Get last run date for this Action
+        id: get_last_run_date
+        run: |
+          LAST_RUN_DATE=$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/ministryofjustice/data-catalogue/actions/runs \
+          --jq '.workflow_runs[] 
+            | select(.conclusion=="success" and .status=="completed" and .path=={{ github.action_path }}) 
+            | .run_started_at' \
+          | head -n 1)
+          echo "last_run_date=${LAST_RUN_DATE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Read minimal version from values.yaml
+        id: read_minimal_version
+        run: |
+          MINIMAL_VERSION=$(python -c "import yaml; print(yaml.safe_load(open('helm_deploy/values.yaml'))['global']['datahub']['version'])")
+          echo "minimal_version=${MINIMAL_VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install semantic-version
+
+      - name: Filter advisories
+        id: filter_advisories
+        run: python scripts/filter_advisories.py \
+          "${{ steps.read_minimal_version.outputs.minimal_version }}" \
+          "${{ steps.get_last_run_date.outputs.last_run_date }}"
+          
+      - name: Send advisories to Slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: 'C071VNHPUHZ'
+          payload-file-path: "./filtered_advisories.json"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.VULN_CHECK_SLACK_BOT_TOKEN }}

--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -1,4 +1,4 @@
-name: Security Advisory Alert
+name: DataHub Security Advisory Alert
 
 on:
   schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,58 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+.tox/
+.coverage
+coverage/
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+# Sphinx documentation
+docs/_build/
+
+# other
 .env
 .terraform/
-coverage/
 venv/
 env/
 .DS_STORE

--- a/scripts/filter_advisories.py
+++ b/scripts/filter_advisories.py
@@ -1,0 +1,126 @@
+import csv
+import json
+import re
+import sys
+from datetime import datetime
+from typing import Any, Dict, List
+
+import semantic_version
+
+
+def to_snake_case(s: str) -> str:
+    """Convert a string to snake_case."""
+    return re.sub(r"\W|^(?=\d)", "_", s).lower()
+
+
+def parse_advisories(filename: str) -> List[Dict[str, Any]]:
+    """Load advisories from a JSON file."""
+    with open(filename, "r") as f:
+        return json.load(f)
+
+
+def filter_advisories(
+    advisories: List[Dict[str, Any]],
+    minimal_version: semantic_version.Version,
+    last_run_date: datetime,
+) -> List[Dict[str, Any]]:
+    """Filter advisories based on the minimal vulnerable version and publication date."""
+    filtered = []
+    for advisory in advisories:
+        published_at = datetime.fromisoformat(advisory.get("published_at", ""))
+        if published_at > last_run_date:
+            for vulnerability in advisory.get("vulnerabilities", []):
+                vulnerable_range = vulnerability.get("vulnerable_version_range", "")
+                if vulnerable_range:
+                    try:
+                        if vulnerable_range == "ALL":
+                            filtered.append(advisory)
+                            break
+                        parsed_vulnerable_range = re.sub(
+                            "v(\\d[.])", "\\1", vulnerable_range
+                        ).replace(" ", "")
+                        range_spec = semantic_version.NpmSpec(parsed_vulnerable_range)
+                        if minimal_version in range_spec:
+                            filtered.append(advisory)
+                            break
+                    except ValueError:
+                        filtered.append(advisory)
+                        break
+    return filtered
+
+
+def advisory_to_slack_block(advisory):
+    severity = advisory["severity"]
+    high_severity = False
+    if severity in ["high", "critical"]:
+        severity = f":alert: *{severity}* :alert:"
+        high_severity = True
+    return {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f"New <https://github.com/datahub-project/datahub/security/advisories|DataHub Security Advisory>:\n"
+            f"*ID:* {advisory['ghsa_id']}\n"
+            f"*Severity:* {severity}\n"
+            f"*Published:* {advisory['published_at']}\n"
+            f"*Summary:* {advisory['summary']}\n"
+            f"*Vulnerable Versions:* {';'.join([v['vulnerable_version_range'] for v in advisory.get('vulnerabilities', [])])}\n"
+            f"*Patched Versions:* {';'.join([v['patched_versions'] for v in advisory.get('vulnerabilities', [])])}\n"
+            f"*Advisory:* {advisory['html_url']}\n",
+        },
+    }, high_severity
+
+
+def main():
+    # Load advisories
+    advisories = parse_advisories("advisories.json")
+
+    # Define the minimal version to compare against
+    # Set default last run date to the year 2000 if not provided
+    if len(sys.argv) < 3:
+        last_run_date_str = "2000-01-01T00:00:00Z"
+    else:
+        last_run_date_str = sys.argv[2]
+    minimal_version_str = re.sub("v(\\d[.])", "\\1", sys.argv[1])
+    minimal_version = semantic_version.Version(minimal_version_str)
+    last_run_date = datetime.fromisoformat(last_run_date_str)
+
+    if not minimal_version:
+        print(f"Invalid minimal version: {minimal_version_str}")
+        sys.exit(1)
+
+    # Filter advisories
+    filtered_advisories = filter_advisories(advisories, minimal_version, last_run_date)
+
+    slack_blocks = []
+    high_severity = False
+    for advisory in filtered_advisories:
+        if slack_blocks:
+            slack_blocks.append({"type": "divider"})
+        advisory_block, block_severity = advisory_to_slack_block(advisory)
+        slack_blocks.append(advisory_block)
+        if block_severity and not high_severity:
+            slack_blocks.insert(
+                0,
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": ":alert: contains _high severity_ advisory :alert:",
+                    },
+                },
+            )
+            slack_blocks.insert(1, {"type": "divider"})
+            high_severity = block_severity
+
+    output = {"blocks": slack_blocks}
+
+    with open("filtered_advisories.json", "w") as f:
+        json.dump(output, f, indent=2)
+
+    # Output the number of found advisories for GitHub Actions
+    print(f"::set-output name=found_advisories::{len(filtered_advisories)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/filter_advisories.py
+++ b/scripts/filter_advisories.py
@@ -106,7 +106,7 @@ def main():
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": ":alert: contains _high severity_ advisory :alert:",
+                        "text": ":warning: contains _high severity_ advisory :warning:",
                     },
                 },
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+# tests/conftest.py
+import os
+import sys
+
+# Add the project root directory to the sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_filter_advisories.py
+++ b/tests/test_filter_advisories.py
@@ -1,0 +1,232 @@
+import json
+from datetime import datetime
+
+import pytest
+import semantic_version
+
+from scripts.filter_advisories import (
+    ValidationError,
+    advisory_to_slack_block,
+    filter_advisories,
+    format_slack_output,
+    parse_vulnerabilities,
+)
+
+
+@pytest.fixture
+def advisories():
+    return [
+        {
+            "ghsa_id": "GHSA-xxxx-xxxx-xxxx",
+            "severity": "medium",
+            "published_at": "2023-06-01T00:00:00Z",
+            "summary": "This is a test advisory",
+            "html_url": "https://github.com/datahub-project/datahub/security/advisories/GHSA-xxxx-xxxx-xxxx",
+            "vulnerabilities": [
+                {
+                    "vulnerable_version_range": "< 0.12.0",
+                    "patched_versions": ">= 0.12.0",
+                }
+            ],
+        },
+        {
+            "ghsa_id": "GHSA-yyyy-yyyy-yyyy",
+            "severity": "high",
+            "published_at": "2023-07-01T00:00:00Z",
+            "summary": "This is another test advisory",
+            "html_url": "https://github.com/datahub-project/datahub/security/advisories/GHSA-yyyy-yyyy-yyyy",
+            "vulnerabilities": [
+                {
+                    "vulnerable_version_range": "ALL",
+                    "patched_versions": "",
+                }
+            ],
+        },
+        {
+            "ghsa_id": "GHSA-zzzz-zzzz-zzzz",
+            "severity": "critical",
+            "published_at": "2023-08-01T00:00:00Z",
+            "summary": "This is yet another test advisory",
+            "html_url": "https://github.com/datahub-project/datahub/security/advisories/GHSA-zzzz-zzzz-zzzz",
+            "vulnerabilities": [
+                {
+                    "vulnerable_version_range": "<= 0.10.1",
+                    "patched_versions": "",
+                },
+                {
+                    "vulnerable_version_range": "= 0.11.1",
+                    "patched_versions": "",
+                },
+            ],
+        },
+    ]
+
+
+class TestFilterAdvisories:
+
+    @pytest.mark.parametrize(
+        "minimal_version,last_run_date,expected_count,expected_ids",
+        [
+            (
+                "0.11.0",
+                "2023-05-31T00:00:00+00:00",
+                2,
+                ["GHSA-xxxx-xxxx-xxxx", "GHSA-yyyy-yyyy-yyyy"],
+            ),
+            (
+                "0.12.0",
+                "2023-05-31T00:00:00+00:00",
+                1,
+                ["GHSA-yyyy-yyyy-yyyy"],
+            ),
+            (
+                "0.11.1",
+                "2023-05-31T00:00:00+00:00",
+                3,
+                ["GHSA-xxxx-xxxx-xxxx", "GHSA-yyyy-yyyy-yyyy", "GHSA-zzzz-zzzz-zzzz"],
+            ),
+            (
+                "0.11.1",
+                "2023-07-02T00:00:00+00:00",
+                1,
+                ["GHSA-zzzz-zzzz-zzzz"],
+            ),
+        ],
+    )
+    def test_filter_advisories(
+        self, advisories, minimal_version, last_run_date, expected_count, expected_ids
+    ):
+        minimal_version = semantic_version.Version(minimal_version)
+        last_run_date = datetime.fromisoformat(last_run_date)
+
+        filtered = filter_advisories(advisories, minimal_version, last_run_date)
+        assert len(filtered) == expected_count
+        assert [adv["ghsa_id"] for adv in filtered] == expected_ids
+
+    def test_filter_advisories_validation_error(self):
+        minimal_version = semantic_version.Version("0.11.0")
+        last_run_date = datetime.fromisoformat("2023-06-01T00:00:00+00:00")
+        broken_advisories = [{"ghsa_id": "GHSA-zzzz-zzzz-zzzz", "published_at": ""}]
+
+        with pytest.raises(ValidationError):
+            filter_advisories(broken_advisories, minimal_version, last_run_date)
+
+
+class TestParseVulnerabilities:
+
+    @pytest.mark.parametrize(
+        "minimal_version,advisory_id,expected_count,expected_ids",
+        [
+            ("0.11.0", "GHSA-xxxx-xxxx-xxxx", 1, ["GHSA-xxxx-xxxx-xxxx"]),
+            ("0.12.0", "GHSA-xxxx-xxxx-xxxx", 0, []),
+            ("0.11.0", "GHSA-yyyy-yyyy-yyyy", 1, ["GHSA-yyyy-yyyy-yyyy"]),
+            ("0.11.0", "GHSA-zzzz-zzzz-zzzz", 0, []),
+            ("0.11.1", "GHSA-zzzz-zzzz-zzzz", 1, ["GHSA-zzzz-zzzz-zzzz"]),
+            ("0.10.0", "GHSA-zzzz-zzzz-zzzz", 1, ["GHSA-zzzz-zzzz-zzzz"]),
+        ],
+    )
+    def test_parse_vulnerabilities(
+        self, advisories, minimal_version, advisory_id, expected_count, expected_ids
+    ):
+        minimal_version = semantic_version.Version(minimal_version)
+        filtered = []
+
+        advisory = next(adv for adv in advisories if adv["ghsa_id"] == advisory_id)
+        filtered = parse_vulnerabilities(advisory, filtered, minimal_version)
+
+        assert len(filtered) == expected_count
+        assert [adv["ghsa_id"] for adv in filtered] == expected_ids
+
+    @pytest.mark.parametrize(
+        "advisory",
+        [
+            {
+                "ghsa_id": "GHSA-zzzz-zzzz-zzzz",
+                "severity": "low",
+                "published_at": "2023-06-03T00:00:00Z",
+                "summary": "Missing vulnerable version range",
+                "html_url": "https://github.com/datahub-project/datahub/security/advisories/GHSA-zzzz-zzzz-zzzz",
+                "vulnerabilities": [{}],
+            }
+        ],
+    )
+    def test_parse_vulnerabilities_validation_error(self, advisory):
+        minimal_version = semantic_version.Version("0.11.0")
+        filtered = []
+
+        with pytest.raises(ValidationError):
+            parse_vulnerabilities(advisory, filtered, minimal_version)
+
+    def test_parse_vulnerabilities_invalid_version(self):
+        minimal_version = semantic_version.Version("0.11.0")
+        filtered = []
+
+        advisory = {
+            "ghsa_id": "GHSA-aaaa-aaaa-aaaa",
+            "severity": "low",
+            "published_at": "2023-06-04T00:00:00Z",
+            "summary": "Invalid version range",
+            "html_url": "https://github.com/datahub-project/datahub/security/advisories/GHSA-aaaa-aaaa-aaaa",
+            "vulnerabilities": [{"vulnerable_version_range": "invalid_version"}],
+        }
+        filtered = parse_vulnerabilities(advisory, filtered, minimal_version)
+        assert len(filtered) == 1
+        assert filtered[0]["ghsa_id"] == advisory["ghsa_id"]
+
+
+class TestAdvisoryToSlackBlock:
+
+    @pytest.mark.parametrize(
+        "advisory_id,expected_high_severity",
+        [
+            ("GHSA-xxxx-xxxx-xxxx", False),
+            ("GHSA-yyyy-yyyy-yyyy", True),
+        ],
+    )
+    def test_advisory_to_slack_block(
+        self, advisories, advisory_id, expected_high_severity
+    ):
+        advisory = next(adv for adv in advisories if adv["ghsa_id"] == advisory_id)
+        block, high_severity = advisory_to_slack_block(advisory)
+
+        assert block["type"] == "section"
+        assert block["text"]["type"] == "mrkdwn"
+        assert f"*ID:* {advisory['ghsa_id']}" in block["text"]["text"]
+        assert high_severity == expected_high_severity
+
+
+class TestFormatSlackOutput:
+
+    @pytest.mark.parametrize(
+        "filtered_advisory_ids,expected_block_count,contains_high_severity",
+        [
+            (["GHSA-xxxx-xxxx-xxxx", "GHSA-yyyy-yyyy-yyyy"], 5, True),
+            (["GHSA-xxxx-xxxx-xxxx"], 1, False),
+            (["GHSA-yyyy-yyyy-yyyy"], 3, True),
+        ],
+    )
+    def test_format_slack_output(
+        self,
+        advisories,
+        filtered_advisory_ids,
+        expected_block_count,
+        contains_high_severity,
+    ):
+        filtered_advisories = [
+            adv for adv in advisories if adv["ghsa_id"] in filtered_advisory_ids
+        ]
+        result = format_slack_output(filtered_advisories)
+        assert len(result["blocks"]) == expected_block_count
+
+        if contains_high_severity:
+            assert result["blocks"][0]["type"] == "section"
+            assert (
+                ":warning: contains _high severity_ advisory :warning:"
+                in result["blocks"][0]["text"]["text"]
+            )
+        else:
+            assert result["blocks"][0]["type"] == "section"
+            assert (
+                f"*ID:* {filtered_advisory_ids[0]}"
+                in result["blocks"][0]["text"]["text"]
+            )

--- a/tests/test_filter_advisories.py
+++ b/tests/test_filter_advisories.py
@@ -115,26 +115,26 @@ class TestFilterAdvisories:
 class TestParseVulnerabilities:
 
     @pytest.mark.parametrize(
-        "minimal_version,advisory_id,expected_count,expected_ids",
+        "minimal_version,advisory_id,expected_ids",
         [
-            ("0.11.0", "GHSA-xxxx-xxxx-xxxx", 1, ["GHSA-xxxx-xxxx-xxxx"]),
-            ("0.12.0", "GHSA-xxxx-xxxx-xxxx", 0, []),
-            ("0.11.0", "GHSA-yyyy-yyyy-yyyy", 1, ["GHSA-yyyy-yyyy-yyyy"]),
-            ("0.11.0", "GHSA-zzzz-zzzz-zzzz", 0, []),
-            ("0.11.1", "GHSA-zzzz-zzzz-zzzz", 1, ["GHSA-zzzz-zzzz-zzzz"]),
-            ("0.10.0", "GHSA-zzzz-zzzz-zzzz", 1, ["GHSA-zzzz-zzzz-zzzz"]),
+            ("0.11.0", "GHSA-xxxx-xxxx-xxxx", ["GHSA-xxxx-xxxx-xxxx"]),
+            ("0.12.0", "GHSA-xxxx-xxxx-xxxx", []),
+            ("0.11.0", "GHSA-yyyy-yyyy-yyyy", ["GHSA-yyyy-yyyy-yyyy"]),
+            ("0.11.0", "GHSA-zzzz-zzzz-zzzz", []),
+            ("0.11.1", "GHSA-zzzz-zzzz-zzzz", ["GHSA-zzzz-zzzz-zzzz"]),
+            ("0.10.0", "GHSA-zzzz-zzzz-zzzz", ["GHSA-zzzz-zzzz-zzzz"]),
         ],
     )
     def test_parse_vulnerabilities(
-        self, advisories, minimal_version, advisory_id, expected_count, expected_ids
+        self, advisories, minimal_version, advisory_id, expected_ids
     ):
         minimal_version = semantic_version.Version(minimal_version)
         filtered = []
 
         advisory = next(adv for adv in advisories if adv["ghsa_id"] == advisory_id)
-        filtered = parse_vulnerabilities(advisory, filtered, minimal_version)
+        parse_vulnerabilities(advisory, filtered, minimal_version)
 
-        assert len(filtered) == expected_count
+        assert len(filtered) == len(expected_ids)
         assert [adv["ghsa_id"] for adv in filtered] == expected_ids
 
     @pytest.mark.parametrize(
@@ -169,7 +169,7 @@ class TestParseVulnerabilities:
             "html_url": "https://github.com/datahub-project/datahub/security/advisories/GHSA-aaaa-aaaa-aaaa",
             "vulnerabilities": [{"vulnerable_version_range": "invalid_version"}],
         }
-        filtered = parse_vulnerabilities(advisory, filtered, minimal_version)
+        parse_vulnerabilities(advisory, filtered, minimal_version)
         assert len(filtered) == 1
         assert filtered[0]["ghsa_id"] == advisory["ghsa_id"]
 

--- a/tests/test_filter_advisories.py
+++ b/tests/test_filter_advisories.py
@@ -200,9 +200,17 @@ class TestFormatSlackOutput:
     @pytest.mark.parametrize(
         "filtered_advisory_ids,expected_block_count,contains_high_severity",
         [
-            (["GHSA-xxxx-xxxx-xxxx", "GHSA-yyyy-yyyy-yyyy"], 5, True),
-            (["GHSA-xxxx-xxxx-xxxx"], 1, False),
-            (["GHSA-yyyy-yyyy-yyyy"], 3, True),
+            (
+                ["GHSA-xxxx-xxxx-xxxx", "GHSA-yyyy-yyyy-yyyy"],
+                5,  # 5 blocks: 1x warning, 2x div, 2x advisory
+                True,
+            ),
+            (["GHSA-xxxx-xxxx-xxxx"], 1, False),  # 1 blocks: 1x advisory
+            (
+                ["GHSA-yyyy-yyyy-yyyy"],
+                3,  # 3 blocks: 1x warning, 1x div, 1x advisory
+                True,
+            ),
         ],
     )
     def test_format_slack_output(


### PR DESCRIPTION
add workflow that:
- fetches DataHub security advisories via GitHub CLI
- parses the response for any matching our version (since the last run of the workflow)
- posts any matching advisories (or any advisories with unparsable vulnerable versions) to Slack
  - add a warning at the top of the message if `high` or `critical` severity alerts contained in the message

add python script for parsing advisories json and outputting slack-formatted message, with tests