### PR TITLE
Fix pod security warnings

### DIFF
--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -5,6 +5,7 @@ datahub-gms:
     repository: acryldata/datahub-gms
   securityContext:
     runAsUser: 100
+    allowPrivilegeEscalation: false
   resources:
     limits:
       memory: 2Gi
@@ -59,7 +60,6 @@ datahub-frontend:
       cpu: 100m
       memory: 512Mi
   podSecurityContext:
-    allowPrivilegeEscalation: false
     fsGroup: 101
   securityContext:
     allowPrivilegeEscalation: false
@@ -132,6 +132,8 @@ elasticsearchSetupJob:
       value: "true"
     - name: OPENSEARCH_USE_AWS_IAM_AUTH
       value: "true"
+  securityContext:
+    allowPrivilegeEscalation: false
 
 kafkaSetupJob:
   enabled: true

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -6,6 +6,8 @@ datahub-gms:
   securityContext:
     runAsUser: 100
     allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
     runAsNonRoot: true
     capabilities:
       drop: ["ALL"]
@@ -67,6 +69,8 @@ datahub-frontend:
     fsGroup: 101
   securityContext:
     allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
     runAsUser: 100
     runAsNonRoot: true
     capabilities:
@@ -108,6 +112,8 @@ acryl-datahub-actions:
     fsGroup: 103
   securityContext:
     allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
     runAsUser: 102
     runAsNonRoot: true
     capabilities:
@@ -146,6 +152,8 @@ elasticsearchSetupJob:
       value: "true"
   securityContext:
     allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
     runAsNonRoot: true
     runAsUser: 100
     capabilities:
@@ -169,6 +177,8 @@ kafkaSetupJob:
     fsGroup: 101
   securityContext:
     allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
     runAsUser: 1000
     runAsNonRoot: true
     capabilities:
@@ -202,6 +212,8 @@ postgresqlSetupJob:
     fsGroup: 101
   securityContext:
     allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
     runAsUser: 1000
     runAsNonRoot: true
     capabilities:
@@ -238,6 +250,8 @@ datahubUpgrade:
     fsGroup: 101
   securityContext:
     allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
     runAsUser: 100
     runAsNonRoot: true
     capabilities:
@@ -306,6 +320,8 @@ datahubSystemUpdate:
     fsGroup: 101
   securityContext:
     allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
     runAsUser: 100
     runAsNonRoot: true
     capabilities:

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -155,7 +155,7 @@ elasticsearchSetupJob:
     seccompProfile:
       type: RuntimeDefault
     runAsNonRoot: true
-    runAsUser: 100
+    runAsUser: 1000
     capabilities:
       drop: ["ALL"]
       add: ["NET_BIND_SERVICE"]

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -34,7 +34,7 @@ datahub-frontend:
     - name: datahub-users
       secret:
         defaultMode: 0444
-        secretName:  datahub-users-secret
+        secretName: datahub-users-secret
   extraVolumeMounts:
     - name: datahub-users
       mountPath: /datahub-frontend/conf/user.props
@@ -51,8 +51,7 @@ datahub-frontend:
     type: ClusterIP
   serviceMonitor:
     create: true
-  lifecycle:
-    {}
+  lifecycle: {}
   resources:
     limits:
       memory: 1400Mi
@@ -60,8 +59,10 @@ datahub-frontend:
       cpu: 100m
       memory: 512Mi
   podSecurityContext:
+    allowPrivilegeEscalation: false
     fsGroup: 101
   securityContext:
+    allowPrivilegeEscalation: false
     runAsUser: 100
   # Set up ingress to expose react front-end
   ingress:
@@ -98,11 +99,12 @@ acryl-datahub-actions:
   podSecurityContext:
     fsGroup: 103
   securityContext:
+    allowPrivilegeEscalation: false
     runAsUser: 102
   image:
     repository: acryldata/datahub-actions
     tag: v0.0.15
-  # mount the k8s secret as a volume in the container, each key name is mounted as a 
+  # mount the k8s secret as a volume in the container, each key name is mounted as a
   # file on the mount path /etc/datahub/ingestion-secret-files
   # ingestionSecretFiles:
   #   name: ${K8S_SECRET_NAME}
@@ -147,6 +149,7 @@ kafkaSetupJob:
   podSecurityContext:
     fsGroup: 101
   securityContext:
+    allowPrivilegeEscalation: false
     runAsUser: 1000
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
@@ -174,6 +177,7 @@ postgresqlSetupJob:
   podSecurityContext:
     fsGroup: 101
   securityContext:
+    allowPrivilegeEscalation: false
     runAsUser: 1000
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
@@ -205,6 +209,7 @@ datahubUpgrade:
   podSecurityContext:
     fsGroup: 101
   securityContext:
+    allowPrivilegeEscalation: false
     runAsUser: 100
   podAnnotations: {}
   extraSidecars: []
@@ -268,6 +273,7 @@ datahubSystemUpdate:
   podSecurityContext:
     fsGroup: 101
   securityContext:
+    allowPrivilegeEscalation: false
     runAsUser: 100
   podAnnotations: {}
   resources:
@@ -419,7 +425,6 @@ global:
             secretKeyRef:
               name: rds-postgresql-instance-output
               key: database_name
-
 
   datahub:
     version: v0.13.2

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -6,6 +6,10 @@ datahub-gms:
   securityContext:
     runAsUser: 100
     allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+      add: ["NET_BIND_SERVICE"]
   resources:
     limits:
       memory: 2Gi
@@ -64,6 +68,10 @@ datahub-frontend:
   securityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+      add: ["NET_BIND_SERVICE"]
   # Set up ingress to expose react front-end
   ingress:
     enabled: true
@@ -101,6 +109,10 @@ acryl-datahub-actions:
   securityContext:
     allowPrivilegeEscalation: false
     runAsUser: 102
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+      add: ["NET_BIND_SERVICE"]
   image:
     repository: acryldata/datahub-actions
     tag: v0.0.15
@@ -134,6 +146,11 @@ elasticsearchSetupJob:
       value: "true"
   securityContext:
     allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 100
+    capabilities:
+      drop: ["ALL"]
+      add: ["NET_BIND_SERVICE"]
 
 kafkaSetupJob:
   enabled: true
@@ -153,6 +170,11 @@ kafkaSetupJob:
   securityContext:
     allowPrivilegeEscalation: false
     runAsUser: 1000
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+      add: ["NET_BIND_SERVICE"]
+
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-5"
@@ -181,6 +203,10 @@ postgresqlSetupJob:
   securityContext:
     allowPrivilegeEscalation: false
     runAsUser: 1000
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+      add: ["NET_BIND_SERVICE"]
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-5"
@@ -213,6 +239,10 @@ datahubUpgrade:
   securityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+      add: ["NET_BIND_SERVICE"]
   podAnnotations: {}
   extraSidecars: []
   cleanupJob:
@@ -277,6 +307,10 @@ datahubSystemUpdate:
   securityContext:
     allowPrivilegeEscalation: false
     runAsUser: 100
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+      add: ["NET_BIND_SERVICE"]
   podAnnotations: {}
   resources:
     limits:


### PR DESCRIPTION
Set `allowPrivilegeEscalation` `seccompProfile` `runAsNonRoot` `capabilities` in line with [kubernetes pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/).

This gets rid of most of the warnings whenever we deploy the helm chart. (https://github.com/ministryofjustice/data-catalogue/issues/27)

`allowPrivilegeEscalation` is documented (poorly) at
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#securitycontext-v1-core
and clarified in this article https://medium.com/pareture/how-allowprivilegeescalation-works-in-kubernetes-ce696494f87b

TL;DR this will set [NoNewPrivileges](https://github.com/moby/moby/issues/20329) to 1 on the containers, which defends against privilege escalation.

Using `RuntimeDefault` for the seccompProfile means the container runtime's default profile will be used for [seccomp](https://docs.docker.com/engine/security/seccomp/), which should restrict the container to a reasonable set of syscalls.

For the most part we were already using `runAsUser` so we are not relying on running as root. The only one I needed to change was `elasticsearchSetupJob` - this now matches the values here https://github.com/acryldata/datahub-helm/blob/2b1d1ab0ca869926829068cc4caff14d90f8f807/charts/datahub/values.yaml#L142-L143

For capabilities, the policy requires that we drop everything and add only what we need. See https://man7.org/linux/man-pages/man7/capabilities.7.html

I've removed everything except for the ability to bind to ports below 1024 (CAP_NET_BIND_SERVICE)

The remaining warnings are not security related. They are caused by us using `secretKeyRef` which created maps in our YAML.

```
coalesce.go:289: warning: destination for datahub.global.sql.datasource.username is a table. Ignoring non-table value (root)
coalesce.go:289: warning: destination for datahub.datahub-gms.global.sql.datasource.username is a table. Ignoring non-table value (datahub)
coalesce.go:289: warning: destination for datahub.datahub-mce-consumer.global.sql.datasource.username is a table. Ignoring non-table value (datahub)
coalesce.go:289: warning: destination for datahub.global.sql.datasource.username is a table. Ignoring non-table value (root)
coalesce.go:289: warning: destination for datahub.sql.datasource.username is a table. Ignoring non-table value (root)
coalesce.go:289: warning: destination for datahub.datahub-gms.global.sql.datasource.username is a table. Ignoring non-table value (datahub)
coalesce.go:289: warning: destination for datahub.sql.datasource.username is a table. Ignoring non-table value (root)
coalesce.go:289: warning: destination for datahub.sql.datasource.username is a table. Ignoring non-table value (root)
```