### PR TITLE
add custom cadet tag transformer

### DIFF
--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -25,14 +25,6 @@ source:
     stateful_ingestion:
       remove_stale_metadata: true
 transformers:
-  - type: "pattern_add_dataset_domain"
+  - type: "add_dataset_tags"
     config:
-      semantics: OVERWRITE
-      domain_pattern:
-        rules:
-          'urn:li:dataset:\(urn:li:dataPlatform:dbt,awsdatacatalog.*common_platform.*':
-            ["HMCTS"]
-          'urn:li:dataset:\(urn:li:dataPlatform:dbt,awsdatacatalog.*prison.*':
-            ["HMPPS"]
-          'urn:li:dataset:\(urn:li:dataPlatform:dbt,awsdatacatalog.*sirius.*':
-            ["OPG"]
+      get_tags_to_add: "ingestion.cadet_display_in_catalogue_tagger.add_display_in_catalogue_tag"

--- a/ingestion/cadet_display_in_catalogue_tagger.py
+++ b/ingestion/cadet_display_in_catalogue_tagger.py
@@ -1,0 +1,17 @@
+import logging
+from typing import List
+
+import datahub.emitter.mce_builder as builder
+from datahub.metadata.schema_classes import TagAssociationClass
+
+
+def add_display_in_catalogue_tag(entity_urn: str) -> List[TagAssociationClass]:
+    """Compute the tags to associate to a given dataset."""
+    if "athena_cadet" not in entity_urn:
+        tag_urn = builder.make_tag_urn(tag="display_in_catalogue")
+        tags = [TagAssociationClass(tag=tag_urn)]
+
+        logging.info(f"Tagging dataset {entity_urn} with {tags}.")
+    else:
+        tags = []
+    return tags


### PR DESCRIPTION
This is to add in a transformer and custom transformer script to tag the dbt platform entities with `display_in_catalogue` leaving the entities created as the athena target platform untagged and hence not returned in search results in find-moj-data

https://github.com/ministryofjustice/find-moj-data/issues/351
