### PR TITLE
Fix reusable workflow

### DIFF
--- a/.github/workflows/ingest-cadet-metadata.yml
+++ b/.github/workflows/ingest-cadet-metadata.yml
@@ -5,35 +5,35 @@ permissions:
   contents: read
 
 on:
-  workflow_dispatch:
-    inputs:
-      env:
-        description: "which environment to deploy to"
-        required: true
-        type: string
-      ecr_region:
-        description: "ecr region to connect to"
-        required: false
-        type: string
-        default: eu-west-1
   workflow_call:
     inputs:
-      env:
-        description: "which environment to deploy to"
-        required: true
-        type: string
-      ecr_region:
+      ECR_REGION:
         description: "ecr region to connect to"
         required: false
         type: string
         default: eu-west-1
+      ENVIRONMENT:
+        description: "Environment to use for secrets"
+        required: true
+        type: string
+    secrets:
+      DATAHUB_GMS_TOKEN:
+        description: "API Key for datahub GMS"
+        required: true
+      CADET_METADATA_ROLE_TO_ASSUME:
+        description: "AWS role to assume, which can access CaDeT metadata in S3"
+        required: true
+      SLACK_ALERT_WEBHOOK:
+        description: "Webhook for posting alerts to the team"
+        required: true
 
 jobs:
   datahub-ingest:
+    environment: ${{ inputs.ENVIRONMENT }}
     timeout-minutes: 120
     runs-on: ubuntu-latest
-    environment: ${{ inputs.env }}
     steps:
+      - run: echo "ENVIRONMENT=${{inputs.ENVIRONMENT}}; URL=${{vars.DATAHUB_GMS_URL}}"
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ingest-dev.yml
+++ b/.github/workflows/ingest-dev.yml
@@ -9,4 +9,9 @@ jobs:
   ingest-cadet-dev:
     uses: ./.github/workflows/ingest-cadet-metadata.yml
     with:
-      env: dev
+      ECR_REGION: eu-west-1
+      ENVIRONMENT: dev
+    secrets:
+      DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
+      CADET_METADATA_ROLE_TO_ASSUME: ${{ secrets.CADET_METADATA_ROLE_TO_ASSUME }}
+      SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.github/workflows/ingest-test-and-preprod.yml
+++ b/.github/workflows/ingest-test-and-preprod.yml
@@ -9,9 +9,19 @@ jobs:
   ingest-cadet-test:
     uses: ./.github/workflows/ingest-cadet-metadata.yml
     with:
-      env: test
+      ECR_REGION: eu-west-1
+      ENVIRONMENT: test
+    secrets:
+      DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
+      CADET_METADATA_ROLE_TO_ASSUME: ${{ secrets.CADET_METADATA_ROLE_TO_ASSUME }}
+      SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}
 
   ingest-cadet-preprod:
     uses: ./.github/workflows/ingest-cadet-metadata.yml
     with:
-      env: preprod
+      ECR_REGION: eu-west-1
+      ENVIRONMENT: preprod
+    secrets:
+      DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
+      CADET_METADATA_ROLE_TO_ASSUME: ${{ secrets.CADET_METADATA_ROLE_TO_ASSUME }}
+      SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}


### PR DESCRIPTION
Reusable workflows don't automatically inherit secrets from the parent workflow, so you can't access them via the `secrets` context without  explicitly passing them through.
    
http://docs.github.com/en/actions/using-workflows/reusing-workflows
    
Note that the environment must still be set by the reusable workflow, NOT the calling workflow. This is unintuitive but it seems like this is just how it works.
    
This behaviour is discussed in https://github.com/orgs/community/discussions/25238#discussioncomment-3247035
    
Variables work differently from secrets and can still be referenced from within a reusable workflow via the `vars` context.

I've removed the workflow dispatch trigger from the reusable workflow for simplicity. I believe it will still work with both `workflow_dispatch` and `workflow_call`, but we don't actually it need it right now.