### PR TITLE
Used latest python 3.11 in ingest workflow

### DIFF
--- a/.github/workflows/ingest-cadet-metadata.yml
+++ b/.github/workflows/ingest-cadet-metadata.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11.1
+          python-version: "3.11"
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.CADET_METADATA_ROLE_TO_ASSUME }}


### PR DESCRIPTION
Poetry was breaking using Python 3.11.1.

The testing workflow uses "3.11" (currently 3.11.9) and works, so I'm aligning the two workflows