### PR TITLE
Alter ES query exact match params for altered 'underscore search' performance

### DIFF
--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -358,6 +358,7 @@ global:
       ## Dynamic settings which do not require reindexing are not affected
       ## Primarily this should be enabled when re-sharding is necessary for scaling/performance.
       enableSettingsReindex: true
+      
 
       ## Index settings can be overridden for entity indices or other indices on an index by index basis
       ## Some index settings, such as # of shards, requires reindexing while others, i.e. replicas, do not
@@ -393,9 +394,9 @@ global:
       ## Configuration around exact matching for search
       exactMatch:
         ## if false will only apply weights, if true will exclude non-exact
-        exclusive: false
+        exclusive: true
         ## include prefix exact matches
-        withPrefix: true
+        withPrefix: false
         ## boost multiplier when exact with case
         exactFactor: 2.0
         ## boost multiplier when exact prefix


### PR DESCRIPTION
[Underscores within exact search in DataHub don't return the expected results](https://github.com/ministryofjustice/find-moj-data/issues/324). A suggestion from the DataHub Slack is:
>setting the environment variable `ELASTICSEARCH_QUERY_EXACT_MATCH_EXCLUSIVE` to true in the GMS causes exact matches with underscores to behave as expected.

This leads to more results than expected - another response suggested:
>[try] disabling `ELASTICSEARCH_QUERY_EXACT_MATCH_WITH_PREFIX` to achieve the desired result

This PR adopts those suggestions