### PR TITLE
Add config to cadet ingestion

### DIFF
--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -20,6 +20,7 @@ source:
     stateful_ingestion:
       remove_stale_metadata: true
     strip_user_ids_from_email: true
+    include_column_lineage: false
     tag_prefix: ""
     meta_mapping:
       owner_email:

--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -19,6 +19,15 @@ source:
       test_definitions: "YES"
     stateful_ingestion:
       remove_stale_metadata: true
+    strip_user_ids_from_email: true
+    tag_prefix: ""
+    meta_mapping:
+      owner_email:
+        match: '.*'
+        operation: 'add_owner'
+        config:
+          owner_type: user
+          owner_category: DATAOWNER
 
 transformers:
   - type: "ingestion.transformers.assign_cadet_domains.AssignDerivedTableDomains"


### PR DESCRIPTION
I have added `include_column_lineage: false` due to an error in the dbt ingestion where the parsing recursion depth is reached https://github.com/ministryofjustice/data-catalogue/actions/runs/9400423298/job/25934112188

`'model.mojap_derived_tables.addressbase_stg__addressbasepremium_hashes': ['Error parsing SQL to generate column lineage: maximum recursion depth exceeded'`