### PR TITLE
use poetry in security-alerts workflow

### DIFF
--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -46,17 +46,43 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install Python dependencies
-        run: |
-          pip install --upgrade pip
-          pip install --no-cache-dir -r requirements.txt
+      - name: Load cached Poetry installation
+        id: cached-poetry
+        uses: actions/cache@v4
+        with:
+          path: ~/.local
+          key: poetry-1.7.1-0
+
+      - name: Install Poetry
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.7.1
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: pydeps-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      - name: Install project
+        run: poetry install --no-interaction
 
       - name: Filter advisories
         id: filter_advisories
         env:        
           REPO: datahub
           REPO_OWNER: datahub-project
-        run: python scripts/filter_advisories.py \
+        run: |
+          source .venv/bin/activate
+          python scripts/filter_advisories.py \
           "${{ steps.read_current_version.outputs.current_version }}" \
           "${{ steps.get_last_run_date.outputs.last_run_date }}"
           

--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -95,3 +95,13 @@ jobs:
           payload-file-path: "./filtered_advisories.json"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.VULN_CHECK_SLACK_BOT_TOKEN }}
+
+      - name: Slack failure notification
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ acryl-datahub = {extras = ["dbt"], version = "^0.13.2.4"}
 semantic-version = "^2.10.0"
 botocore = "^1.34.129"
 
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The security-alerts workflow is currently broken, as it used the `requirements.txt` file that was removed in a previous PR. This PR adds poetry package management to the workflow to restore functionality.