### PR TITLE
rename depreciated path and update owner meta tag

### DIFF
--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -26,7 +26,7 @@ source:
       test_definitions: "YES"
     stateful_ingestion:
       remove_stale_metadata: true
-    strip_user_ids_from_email: true
+    strip_user_ids_from_email: false
     include_column_lineage: false
     tag_prefix: ""
     meta_mapping:

--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -5,7 +5,7 @@ source:
       aws_region: eu-west-1
     manifest_path: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/manifest.json"
     catalog_path: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/catalog.json"
-    test_results_path: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/run_results.json"
+    run_results_paths: ["s3://mojap-derived-tables/prod/run_artefacts/latest/target/run_results.json"]
     platform_instance: cadet
     target_platform: athena
     target_platform_instance: athena_cadet
@@ -30,7 +30,7 @@ source:
     include_column_lineage: false
     tag_prefix: ""
     meta_mapping:
-      owner_email:
+      dc_owner:
         match: '.*'
         operation: 'add_owner'
         config:
@@ -45,6 +45,3 @@ transformers:
   - type: "ingestion.transformers.assign_cadet_databases.AssignCadetDatabases"
     config:
       manifest_s3_uri: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/manifest.json"
-  - type: "add_dataset_tags"
-    config:
-      get_tags_to_add: "ingestion.taggers.cadet_display_in_catalogue_tagger.add_display_in_catalogue_tag"


### PR DESCRIPTION
has couple updates to cadet.yaml ingestion recipe.
- `test_results_path` depreciated in favour of `run_result_paths`. The value has also changed from str to list
- remove the transformer that tags every cadet model. We now have some tags populated in the cadet repo
- rename the meta tag for owner to match the name we have defined in the cadet repo

ingestion is currently failing with `RecursionError: maximum recursion depth exceeded` and it's not immediately obvious why. Logs are not too helpful. So could be something wrong within the dbt manifest or configuration of our recipe. It's also true that at time of writing the cadet action that builds docs had broken again so we have an empty catalog file although don;t know if that would cause this error