### PR TITLE
Format domain names

### DIFF
--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -14,7 +14,11 @@ from datahub.metadata.schema_classes import ChangeTypeClass, DomainPropertiesCla
 
 from ingestion.config import ENV, INSTANCE, PLATFORM
 from ingestion.create_cadet_databases_source.config import CreateCadetDatabasesConfig
-from ingestion.dbt_manifest_utils import get_cadet_manifest, validate_fqn
+from ingestion.dbt_manifest_utils import (
+    format_domain_name,
+    get_cadet_manifest,
+    validate_fqn,
+)
 
 
 @config_class(CreateCadetDatabasesConfig)
@@ -79,7 +83,7 @@ class CreateCadetDatabases(Source):
     def _get_domains(self, manifest) -> set[str]:
         """Only models are arranged by domain in CaDeT"""
         return set(
-            manifest["nodes"][node]["fqn"][1]
+            format_domain_name(manifest["nodes"][node]["fqn"][1])
             for node in manifest["nodes"]
             if manifest["nodes"][node]["resource_type"] == "model"
         )

--- a/ingestion/dbt_manifest_utils.py
+++ b/ingestion/dbt_manifest_utils.py
@@ -74,3 +74,21 @@ def convert_cadet_manifest_table_to_datahub(node_info: dict) -> Tuple[str, str]:
     escaped_urn_for_regex = re.escape(urn)
 
     return domain, escaped_urn_for_regex
+
+
+BIG_OLD_ACRONYMS = set(("OPG", "HMPPS", "HMCTS", "LAA", "CICA", "HQ"))
+
+
+def format_domain_name(domain_name: str) -> str:
+    """
+    Format domain names from the manifest into a human readable format, e.g.
+    courts -> Courts
+    opg -> OPG
+    hmpps -> HMPPS
+    electronic_monitoring -> Electronic monitoring
+    """
+    acronym = domain_name.upper()
+    if acronym in BIG_OLD_ACRONYMS:
+        return acronym
+
+    return domain_name.capitalize().replace("_", " ")

--- a/tests/data/manifest.json
+++ b/tests/data/manifest.json
@@ -7,6 +7,10 @@
                 "offence",
                 "prison_database__table1"
             ],
+            "tags": [
+                "weekly",
+                "dc_display_in_catalogue"
+            ],
             "resource_type": "model"
         },
         "model.test_derived_tables.probation": {
@@ -15,6 +19,10 @@
                 "probation",
                 "youth",
                 "probation_database__table1"
+            ],
+            "tags": [
+                "weekly",
+                "dc_display_in_catalogue"
             ],
             "resource_type": "model"
         },
@@ -25,6 +33,10 @@
                 "courts",
                 "courts_data__table1"
             ],
+            "tags": [
+                "weekly",
+                "dc_display_in_catalogue"
+            ],
             "resource_type": "model"
         },
         "model.test_derived_tables.hq": {
@@ -33,6 +45,10 @@
                 "hq",
                 "hq",
                 "hq_database__table1"
+            ],
+            "tags": [
+                "weekly",
+                "dc_display_in_catalogue"
             ],
             "resource_type": "model"
         },
@@ -43,6 +59,10 @@
                 "offence",
                 "invalid_tablename"
             ],
+            "tags": [
+                "weekly",
+                "dc_display_in_catalogue"
+            ],
             "resource_type": "model"
         },
         "seed.test_derived_tables.nope": {
@@ -52,6 +72,10 @@
                 "test_derived_tables",
                 "table1"
             ],
+            "tags": [
+                "weekly",
+                "dc_display_in_catalogue"
+            ],
             "resource_type": "seed"
         },
         "source.test_derived_tables.nope": {
@@ -60,6 +84,10 @@
                 "nope",
                 "test_derived_tables",
                 "table1"
+            ],
+            "tags": [
+                "weekly",
+                "dc_display_in_catalogue"
             ],
             "resource_type": "source"
         }

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -16,15 +16,12 @@ def test_creating_domains_from_s3():
 
     results = list(source.get_workunits())
 
-    assert results
-    assert len(results) == 24
-
     domain_creation_events = results[:4]
     domains = [event.metadata.aspect.name for event in domain_creation_events]
     domains.sort()
-    assert domains == ["courts", "hq", "prison", "probation"]
+    assert domains == ["Courts", "HQ", "Prison", "Probation"]
 
-    # 5 events are created per database, we'll just test one
+    # 6 events are created per database, we'll just test one
     # (create container, update status, add platform, add subtype, associate container with domain)
     assert results[4].metadata.aspect.customProperties.get("database")
     assert results[6].metadata.aspect.platform == builder.make_data_platform_urn(

--- a/tests/test_dbt_manifest_utils.py
+++ b/tests/test_dbt_manifest_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+from ingestion.dbt_manifest_utils import format_domain_name
+
+
+@pytest.mark.parametrize(
+    "original,expected",
+    [
+        ("foo", "Foo"),
+        ("electronic_monitoring", "Electronic monitoring"),
+        ("opg", "OPG"),
+        ("aBcDe", "Abcde"),
+    ],
+)
+def test_format_domain_name(original, expected):
+    assert format_domain_name(original) == expected


### PR DESCRIPTION
Added a helper function to format the domain names we import from CaDeT.

(Paired with @seanprivett on this)

I noticed existing unit tests are not working at the moment so currently looking into this