### PR TITLE
fix bug that assigned dbs to pre-formatted domain

### DIFF
--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -61,10 +61,11 @@ class CreateCadetDatabases(Source):
                 env=ENV,
                 backcompat_env_as_instance=True,
             )
-            domain_urn = mce_builder.make_domain_urn(domain=domain)
+            domain_name = format_domain_name(domain)
+            domain_urn = mce_builder.make_domain_urn(domain=domain_name)
             display_tag = display_tags.get(database)
 
-            logging.info(f"Creating container {database=} with {domain=}")
+            logging.info(f"Creating container {database=} with {domain_name=}")
             yield from mcp_builder.gen_containers(
                 container_key=database_container_key,
                 name=database,


### PR DESCRIPTION
Databases that are created via the manifest were being assigned a domain using the pre-formated name (lowercase) and this was causing some strangeness in datahub and the frontend.

This PR fixes that