### PR TITLE
Refactor db name creation

### DIFF
--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -6,7 +6,7 @@ source:
     manifest_path: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/manifest.json"
     catalog_path: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/catalog.json"
     run_results_paths: ["s3://mojap-derived-tables/prod/run_artefacts/latest/target/run_results.json"]
-    # if this changes it needs to also change in config.py
+    # if platform_instance changes it needs to also change in config.py
     platform_instance: cadet
     target_platform: athena
     target_platform_instance: athena_cadet

--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -6,6 +6,7 @@ source:
     manifest_path: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/manifest.json"
     catalog_path: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/catalog.json"
     run_results_paths: ["s3://mojap-derived-tables/prod/run_artefacts/latest/target/run_results.json"]
+    # if this changes it needs to also change in config.py
     platform_instance: cadet
     target_platform: athena
     target_platform_instance: athena_cadet
@@ -17,6 +18,7 @@ source:
         - ".*use_of_force\\.summary_status_complete_dim.*"
         - ".*use_of_force\\.summary_status_in_progress_dim.*"
         - ".*use_of_force\\.summary_status_submitted_dim.*"
+        - ".*data_eng_uploader_prod_calc_release_dates\\.survey_data.*"
     entities_enabled:
       test_results: "YES"
       seeds: "NO"

--- a/ingestion/config.py
+++ b/ingestion/config.py
@@ -1,3 +1,5 @@
 PLATFORM = "dbt"
+# this needs to match the platform_instance value in cadet.yaml dbt recipe
+# minus the .awscatalog bit
 INSTANCE = "cadet.awsdatacatalog"
 ENV = "PROD"

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -106,7 +106,7 @@ class CreateCadetDatabases(Source):
             if manifest["nodes"][node]["resource_type"] == "model":
                 fqn = manifest["nodes"][node]["fqn"]
                 if validate_fqn(fqn):
-                    database = fqn[-1].split("__")[0]
+                    database = manifest["nodes"][node]["schema"]
                     domain = fqn[1]
                     tag = (
                         "dc_display_in_catalogue"

--- a/ingestion/dbt_manifest_utils.py
+++ b/ingestion/dbt_manifest_utils.py
@@ -62,7 +62,10 @@ def convert_cadet_manifest_table_to_datahub(node_info: dict) -> Tuple[str, str]:
     """
     domain = format_domain_name(node_info.get("fqn", [])[1])
     node_table_name = node_info.get("fqn", [])[-1]
-
+    # schema has the name of the database that has resulted from the filename parsing
+    database_name = node_info.get("schema", "")
+    if database_name.endswith("dev_dbt"):
+        node_table_name = f"{database_name}.{node_table_name.split('__')[-1]}"
     # In CaDeT the convention is to name a table database__table
     node_table_name_no_double_underscore = node_table_name.replace("__", ".")
     urn = builder.make_dataset_urn_with_platform_instance(

--- a/ingestion/dbt_manifest_utils.py
+++ b/ingestion/dbt_manifest_utils.py
@@ -61,18 +61,14 @@ def convert_cadet_manifest_table_to_datahub(node_info: dict) -> Tuple[str, str]:
     like 'urn:li:dataset:\\(urn:li:dataPlatform:dbt,cadet\\.awsdatacatalog\\.database\\.table,PROD\\)'
     """
     domain = format_domain_name(node_info.get("fqn", [])[1])
-    node_table_name = node_info.get("fqn", [])[-1]
-    # schema has the name of the database that has resulted from the filename parsing
-    database_name = node_info.get("schema", "")
-    if database_name.endswith("dev_dbt"):
-        node_table_name = f"{database_name}.{node_table_name.split('__')[-1]}"
-    # In CaDeT the convention is to name a table database__table
-    node_table_name_no_double_underscore = node_table_name.replace("__", ".")
+
+    database_name, table_name = parse_database_and_table_names(node_info)
+
     urn = builder.make_dataset_urn_with_platform_instance(
         platform=PLATFORM,
         platform_instance=INSTANCE,
         env=ENV,
-        name=node_table_name_no_double_underscore,
+        name=f"{database_name}.{table_name}",
     )
     escaped_urn_for_regex = re.escape(urn)
 
@@ -95,3 +91,19 @@ def format_domain_name(domain_name: str) -> str:
         return acronym
 
     return domain_name.capitalize().replace("_", " ")
+
+
+def parse_database_and_table_names(node: dict) -> tuple[str, str]:
+    """
+    takes a node from the dbt manifest and returns the athena database
+    and table names - as populated by the create-a-derived-table service
+    """
+
+    # In CaDeT the convention is to name a table database__table, which is
+    # found in the last item of fqn list.
+    node_table_name = node["fqn"][-1].split("__")[-1]
+    # schema holds the database name after parsing from cadet and so will be
+    # representative of the cadet env (where dev dbs have suffix `_dev_dbt`)
+    node_dataabse_name = node["schema"]
+
+    return node_dataabse_name, node_table_name

--- a/ingestion/transformers/assign_cadet_databases.py
+++ b/ingestion/transformers/assign_cadet_databases.py
@@ -73,9 +73,7 @@ class AssignCadetDatabases(DatasetTransformer, metaclass=ABCMeta):
 
         return mcps
 
-    def _get_table_database_mappings(
-        self, manifest
-    ) -> Dict[str, str]:
+    def _get_table_database_mappings(self, manifest) -> Dict[str, str]:
         mappings = {}
         for node in manifest["nodes"]:
             if manifest["nodes"][node]["resource_type"] == "model":
@@ -83,10 +81,8 @@ class AssignCadetDatabases(DatasetTransformer, metaclass=ABCMeta):
                 if validate_fqn(fqn):
                     node_table_name = fqn[-1]
                     parts = node_table_name.split("__")
-                    database = parts[0]
-                    node_table_name_no_double_underscore = node_table_name.replace(
-                        "__", "."
-                    )
+                    database = manifest["nodes"][node]["schema"]
+                    node_table_name_no_double_underscore = f"{database}.{parts[-1]}"
 
                     dataset_urn = mce_builder.make_dataset_urn_with_platform_instance(
                         name=node_table_name_no_double_underscore,

--- a/ingestion/transformers/assign_cadet_domains.py
+++ b/ingestion/transformers/assign_cadet_domains.py
@@ -51,6 +51,7 @@ class AssignCadetDomains(AddDatasetDomain):
             semantics=config.semantics,
             replace_existing=config.replace_existing,
         )
+
         super().__init__(generic_config, ctx)
 
     @classmethod

--- a/tests/data/manifest.json
+++ b/tests/data/manifest.json
@@ -71,7 +71,7 @@
             "resource_type": "model"
         },
         "seed.test_derived_tables.nope": {
-            "schema": "probation_database",
+            "schema": "test_derived_tables_dev_dbt",
             "fqn": [
                 "model",
                 "nope",

--- a/tests/data/manifest.json
+++ b/tests/data/manifest.json
@@ -1,6 +1,7 @@
 {
     "nodes": {
         "model.test_derived_tables.prison": {
+            "schema": "prison_database",
             "fqn": [
                 "model",
                 "prison",
@@ -14,6 +15,7 @@
             "resource_type": "model"
         },
         "model.test_derived_tables.probation": {
+            "schema": "probation_database",
             "fqn": [
                 "model",
                 "probation",
@@ -27,6 +29,7 @@
             "resource_type": "model"
         },
         "model.test_derived_tables.courts": {
+            "schema": "courts_data",
             "fqn": [
                 "model",
                 "courts",
@@ -40,6 +43,7 @@
             "resource_type": "model"
         },
         "model.test_derived_tables.hq": {
+            "schema": "hq_database",
             "fqn": [
                 "model",
                 "hq",
@@ -53,6 +57,7 @@
             "resource_type": "model"
         },
         "model.test_derived_tables.invalid": {
+            "schema": "invalid",
             "fqn": [
                 "model",
                 "prison",
@@ -66,6 +71,7 @@
             "resource_type": "model"
         },
         "seed.test_derived_tables.nope": {
+            "schema": "probation_database",
             "fqn": [
                 "model",
                 "nope",
@@ -79,6 +85,7 @@
             "resource_type": "seed"
         },
         "source.test_derived_tables.nope": {
+            "schema": "test_derived_tables",
             "fqn": [
                 "model",
                 "nope",

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -4,6 +4,7 @@ from datahub.ingestion.source.common.subtypes import DatasetContainerSubTypes
 
 from ingestion.create_cadet_databases_source.config import CreateCadetDatabasesConfig
 from ingestion.create_cadet_databases_source.source import CreateCadetDatabases
+from ingestion.dbt_manifest_utils import format_domain_name
 
 
 def test_creating_domains_from_s3():
@@ -33,5 +34,6 @@ def test_creating_domains_from_s3():
         results[4].metadata.aspect.customProperties.get("database").split("_")[0]
     )
     assert (
-        builder.make_domain_urn(domain_result_4) in results[8].metadata.aspect.domains
+        builder.make_domain_urn(format_domain_name(domain_result_4))
+        in results[8].metadata.aspect.domains
     )

--- a/tests/test_dbt_manifest_utils.py
+++ b/tests/test_dbt_manifest_utils.py
@@ -1,6 +1,10 @@
 import pytest
+import json
 
-from ingestion.dbt_manifest_utils import format_domain_name
+from ingestion.dbt_manifest_utils import (
+    format_domain_name,
+    parse_database_and_table_names,
+)
 
 
 @pytest.mark.parametrize(
@@ -14,3 +18,38 @@ from ingestion.dbt_manifest_utils import format_domain_name
 )
 def test_format_domain_name(original, expected):
     assert format_domain_name(original) == expected
+
+
+with open("tests/data/manifest.json") as f:
+    test_manifest = json.load(f)
+
+
+@pytest.mark.parametrize(
+    "node, database, table",
+    [
+        (
+            test_manifest["nodes"]["model.test_derived_tables.prison"],
+            "prison_database",
+            "table1",
+        ),
+        (
+            test_manifest["nodes"]["model.test_derived_tables.hq"],
+            "hq_database",
+            "table1",
+        ),
+        (
+            test_manifest["nodes"]["source.test_derived_tables.nope"],
+            "test_derived_tables",
+            "table1",
+        ),
+        (
+            test_manifest["nodes"]["seed.test_derived_tables.nope"],
+            "test_derived_tables_dev_dbt",
+            "table1",
+        ),
+    ],
+)
+def test_parse_database_and_table_names(node, database, table):
+    database_name, table_name = parse_database_and_table_names(node)
+    assert database_name == database
+    assert table_name == table


### PR DESCRIPTION
This PR refactors how we are inferring the database name for create-a-derived-table databases created in athena.

Previously we took the filename and replicated the logic used in cadet prod to parse these into `{database_name}.{table_name}`

However if looking at the dev env of cadet, different logic is applied when parsing the filenames to get database names, with `_dev_dbt` suffix added to every database name. The post parse db name is available for each node under the `schema` key and this PR switches our custom source and transformers to create the database name according to the value in the `schema` key.