### PR TITLE
Disable include_compiled_code to workaround sqlglot bug

### DIFF
--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -26,8 +26,15 @@ source:
       test_definitions: "YES"
     stateful_ingestion:
       remove_stale_metadata: true
-    strip_user_ids_from_email: false
+
+    # SQLglot sometimes raises RecursionError with valid SQL.
+    # See https://github.com/ministryofjustice/find-moj-data/issues/477
+    # Until this is fixed, we should avoid features that depend on
+    # formatting SQL from `node.compiled_code`.
+    include_compiled_code: false
     include_column_lineage: false
+
+    strip_user_ids_from_email: false
     tag_prefix: ""
     meta_mapping:
       dc_owner:


### PR DESCRIPTION
When this setting is true (the default), datahub parses `compiled_code` from the manifest, and attempts to format it with sqlglot.

However, sqlglot uses recursion in its formatting code, which sometimes breaks if you have long column expressions.

This is the case for some of our snapshots in CaDeT, because they concatenate a whole lot of columns together as part of the query.

Recursion has been a problem in other parts of sqlglot before, see https://github.com/tobymao/sqlglot/issues/2961

This setting can be switched back on if the bug is fixed upstream, and datahub has been upgraded to a fixed version.

It looks like we still need to keep `include_column_lineage` disabled, as lineage related functionality also depends on sqlglot formatting.

https://github.com/ministryofjustice/find-moj-data/issues/477