### PR TITLE
add cadet prod ingestion workflow

### DIFF
--- a/.github/workflows/ingest-cadet-metadata.yml
+++ b/.github/workflows/ingest-cadet-metadata.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   datahub-ingest:
     environment: ${{ inputs.ENVIRONMENT }}
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     steps:
       - run: echo "ENVIRONMENT=${{inputs.ENVIRONMENT}}; URL=${{vars.DATAHUB_GMS_URL}}"

--- a/.github/workflows/ingest-prod.yml
+++ b/.github/workflows/ingest-prod.yml
@@ -1,0 +1,17 @@
+name: Ingest cadet metadata to production datahub
+
+on:
+  # schedule:
+  #   - cron: "0 3 * * *" # 3am UTC
+  workflow_dispatch:
+
+jobs:
+  ingest-cadet-prod:
+    uses: ./.github/workflows/ingest-cadet-metadata.yml
+    with:
+      ECR_REGION: eu-west-1
+      ENVIRONMENT: prod
+    secrets:
+      DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
+      CADET_METADATA_ROLE_TO_ASSUME: ${{ secrets.CADET_METADATA_ROLE_TO_ASSUME }}
+      SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}


### PR DESCRIPTION
Adds the workflow to ingest create-a-derived-table metadata into prod datahub.

No schedule set yet but we can easily configure this following a successful run from gha