### PR TITLE
add display tag in justice data source script not via transformer

### DIFF
--- a/ingestion/justice_data_ingest.yaml
+++ b/ingestion/justice_data_ingest.yaml
@@ -2,8 +2,3 @@ source:
   type: ingestion.justice_data_source.source.JusticeDataAPISource
   config:
     base_url: "https://data.justice.gov.uk/api"
-
-transformers:
-  - type: "add_dataset_tags"
-    config:
-      get_tags_to_add: "ingestion.taggers.display_in_catalogue_tagger.add_display_in_catalogue_tag"

--- a/ingestion/justice_data_source/source.py
+++ b/ingestion/justice_data_source/source.py
@@ -19,7 +19,13 @@ from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.com.linkedin.pegasus2avro.common import ChangeAuditStamps, Status
 from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import ChartSnapshot
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
-from datahub.metadata.schema_classes import BrowsePathsV2Class, ChartInfoClass
+from datahub.metadata.schema_classes import (
+    BrowsePathsV2Class,
+    ChartInfoClass,
+    GlobalTagsClass,
+    TagAssociationClass,
+)
+
 
 from .api_client import JusticeDataAPIClient
 from .config import JusticeDataAPIConfig
@@ -76,6 +82,11 @@ class JusticeDataAPISource(TestableSource):
             chartUrl=self.web_url + chart_data.get("permalink", ""),
         )
         chart_snapshot.aspects.append(chart_info)
+
+        # add tag so entity displays in find-moj-data
+        tag_urn = builder.make_tag_urn(tag="dc_display_in_catalogue")
+        display_tag = GlobalTagsClass(tags=[TagAssociationClass(tag_urn)])
+        chart_snapshot.aspects.append(display_tag)
 
         # TODO: browse paths requires IDs, not just titles
         breadcrumb = chart_data.get("breadcrumb")


### PR DESCRIPTION
The display tag transformer previously used for cadet only works on dataset entities so added the tag for all justice data charts as part of the custom source script