### PR TITLE
[WIP] Reenable disabled features

### DIFF
--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -29,12 +29,8 @@ source:
     stateful_ingestion:
       remove_stale_metadata: true
 
-    # SQLglot sometimes raises RecursionError with valid SQL.
-    # See https://github.com/ministryofjustice/find-moj-data/issues/477
-    # Until this is fixed, we should avoid features that depend on
-    # formatting SQL from `node.compiled_code`.
-    include_compiled_code: false
-    include_column_lineage: false
+    include_compiled_code: true
+    include_column_lineage: true
 
     strip_user_ids_from_email: false
     tag_prefix: ""


### PR DESCRIPTION
A couple of fixes have gone into Datahub that I think may resolve the recursion errors we were seeing with 0.13.2.4.

- https://github.com/datahub-project/datahub/pull/10553 was definitely merged before 0.13.3, although may have already been included in 0.13.2.4
- https://github.com/datahub-project/datahub/pull/10678 went into 0.13.3.4

I'd like to retest this on 0.13.3.4 to see if this is the case. If not, then we can report the stack trace to Datahub.

**Do not merge until the [ingestion timing](https://github.com/ministryofjustice/data-catalogue/pull/213) is merged**