### PR TITLE
separate and apply schedule to ingestions

### DIFF
--- a/.github/workflows/ingest-preprod.yml
+++ b/.github/workflows/ingest-preprod.yml
@@ -1,24 +1,24 @@
-name: Ingest metadata to prod
+name: Ingest metadata to preprod on schedule
+
 on:
   schedule:
-    - cron: "0 3 * * *" # 3am UTC
-
+    - cron: "0 9 * * *" # 9am UTC
 
 jobs:
-  ingest-cadet-prod:
+  ingest-cadet-preprod:
     uses: ./.github/workflows/ingest-cadet-metadata.yml
     with:
       ECR_REGION: eu-west-1
-      ENVIRONMENT: prod
+      ENVIRONMENT: preprod
     secrets:
       DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
       CADET_METADATA_ROLE_TO_ASSUME: ${{ secrets.CADET_METADATA_ROLE_TO_ASSUME }}
       SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}
-  ingest-justice-data-prod:
+  ingest-justice-data-preprod:
     uses: ./.github/workflows/ingest-justice-data.yml
     with:
       ECR_REGION: eu-west-1
-      ENVIRONMENT: prod
+      ENVIRONMENT: preprod
     secrets:
       DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
       SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.github/workflows/ingest-preprod.yml
+++ b/.github/workflows/ingest-preprod.yml
@@ -3,6 +3,7 @@ name: Ingest metadata to preprod on schedule
 on:
   schedule:
     - cron: "0 9 * * *" # 9am UTC
+  workflow_dispatch:
 
 jobs:
   ingest-cadet-preprod:

--- a/.github/workflows/ingest-prod.yml
+++ b/.github/workflows/ingest-prod.yml
@@ -2,7 +2,7 @@ name: Ingest metadata to prod
 on:
   schedule:
     - cron: "0 3 * * *" # 3am UTC
-
+  workflow_dispatch:
 
 jobs:
   ingest-cadet-prod:

--- a/.github/workflows/ingest-test.yml
+++ b/.github/workflows/ingest-test.yml
@@ -1,5 +1,4 @@
-name: Ingest metadata to test and preprod
-
+name: Ingest metadata to test
 on:
   # schedule:
   #   - cron: "0 3 * * *" # 3am UTC
@@ -20,24 +19,6 @@ jobs:
     with:
       ECR_REGION: eu-west-1
       ENVIRONMENT: test
-    secrets:
-      DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
-      SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}
-
-  ingest-cadet-preprod:
-    uses: ./.github/workflows/ingest-cadet-metadata.yml
-    with:
-      ECR_REGION: eu-west-1
-      ENVIRONMENT: preprod
-    secrets:
-      DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
-      CADET_METADATA_ROLE_TO_ASSUME: ${{ secrets.CADET_METADATA_ROLE_TO_ASSUME }}
-      SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}
-  ingest-justice-data-preprod:
-    uses: ./.github/workflows/ingest-justice-data.yml
-    with:
-      ECR_REGION: eu-west-1
-      ENVIRONMENT: preprod
     secrets:
       DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
       SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}


### PR DESCRIPTION
This PR separates out each env into it's own ingestion workflow file.

The schedule is:
* **PROD**: daily as 3am
* **PREPROD**: daily 9am
* **TEST**: manually
* **DEV**: manually
