### PR TITLE
fix: default Justice Data domains to "General"

### DIFF
--- a/ingestion/justice_data_source/api_client.py
+++ b/ingestion/justice_data_source/api_client.py
@@ -38,7 +38,7 @@ class JusticeDataAPIClient:
             elif current.get("domain"):
                 domain = current["domain"]
             else:
-                domain = None
+                domain = "General"
 
             current["domain"] = domain
             breadcrumb = current.get("breadcrumb", []).copy()

--- a/tests/test_justice_data_source.py
+++ b/tests/test_justice_data_source.py
@@ -73,7 +73,7 @@ def test_chart(mock_justice_data_api, default_owner_email):
     first_chart_domain = next(
         r.metadata for r in mock_justice_data_api if hasattr(r.metadata, "aspect")
     )
-    assert first_chart_domain.aspect.domains[0] == "urn:li:domain:Courts"
+    assert first_chart_domain.aspect.domains[0] == "urn:li:domain:General"
 
 
 def test_corp_group(mock_justice_data_api, default_owner_email):


### PR DESCRIPTION
This domain already exists as a catchall for anything not assigned to another domain, and we think is will be better to assign entities to General than for an entity to have no domain at all. This way everything we display in Find MoJ data will have a subject area shown.

Part of https://github.com/ministryofjustice/find-moj-data/issues/601

Note: CaDeT entities already have domains set, as part of our custom transformer.