### PR TITLE
ci: update ingestion workflows to use new envs

### DIFF
--- a/.github/workflows/ingest-preprod.yml
+++ b/.github/workflows/ingest-preprod.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/ingest-cadet-metadata.yml
     with:
       ECR_REGION: eu-west-1
-      ENVIRONMENT: preprod
+      ENVIRONMENT: preprod-ingestion
     secrets:
       DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
       CADET_METADATA_ROLE_TO_ASSUME: ${{ secrets.CADET_METADATA_ROLE_TO_ASSUME }}

--- a/.github/workflows/ingest-prod.yml
+++ b/.github/workflows/ingest-prod.yml
@@ -9,7 +9,7 @@ jobs:
     uses: ./.github/workflows/ingest-cadet-metadata.yml
     with:
       ECR_REGION: eu-west-1
-      ENVIRONMENT: prod
+      ENVIRONMENT: prod-ingestion
     secrets:
       DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
       CADET_METADATA_ROLE_TO_ASSUME: ${{ secrets.CADET_METADATA_ROLE_TO_ASSUME }}


### PR DESCRIPTION
PR uses two newly created environments to run ingestion workflows on a schedule that does not require manual approval after being triggered