### PR TITLE
Ingest seeds

### DIFF
--- a/.github/workflows/ingest-cadet-metadata.yml
+++ b/.github/workflows/ingest-cadet-metadata.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           payload: |
             {
-                "text": ":warning: ALERT: DataHub CaDeT metadata ingestion failure on ${{inputs.ENVIRONMENT}}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                "text": ":warning: ALERT: DataHub CaDeT metadata ingestion failure on ${{inputs.ENVIRONMENT}} ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -21,7 +21,7 @@ source:
         - ".*data_eng_uploader_prod_calc_release_dates\\.survey_data.*"
     entities_enabled:
       test_results: "YES"
-      seeds: "NO"
+      seeds: "YES"
       snapshots: "NO"
       models: "YES"
       sources: "YES"

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -112,7 +112,9 @@ class CreateCadetDatabases(Source):
             yield wu
 
     def _get_domains(self, manifest) -> set[str]:
-        """Only models are arranged by domain in CaDeT"""
+        """Only models are arranged by domain in CaDeT.
+        Seeds should only be associated with a domain if it appears in models.
+        """
         return set(
             format_domain_name(manifest["nodes"][node]["fqn"][1])
             for node in manifest["nodes"]
@@ -135,7 +137,7 @@ class CreateCadetDatabases(Source):
         table_mappings = set()
         tags = {}
         for node in manifest["nodes"]:
-            if manifest["nodes"][node]["resource_type"] == "model":
+            if manifest["nodes"][node]["resource_type"] in ["model", "seed"]:
                 fqn = manifest["nodes"][node]["fqn"]
                 if validate_fqn(fqn):
                     database, table = parse_database_and_table_names(

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -116,7 +116,7 @@ class CreateCadetDatabases(Source):
             )
             wu = MetadataWorkUnit("single_mcp", mcp=mcp)
             self.report.report_workunit(wu)
-            logging.info(f"Tagging seed {domain_name} to display in catalogue")
+            logging.info(f"Tagging seed {database}.{table} with dc_display_in_catalogue")
             yield wu
 
 

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -156,8 +156,8 @@ def get_tags(dbt_manifest_node: dict) -> list[str]:
     """Resolve the tags to assign to nodes in datahub."""
     tags = []
     if "dc_display_in_catalogue" in dbt_manifest_node["tags"]:
-        tags += "dc_display_in_catalogue"
+        tags.append("dc_display_in_catalogue")
     if dbt_manifest_node["resource_type"] == "seed":
-        tags += "dc_display_in_catalogue"
+        tags.append("dc_display_in_catalogue")
 
     return tags

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -159,3 +159,5 @@ def get_tags(dbt_manifest_node: dict) -> list[str]:
         tags += "dc_display_in_catalogue"
     if dbt_manifest_node["resource_type"] == "seed":
         tags += "dc_display_in_catalogue"
+
+    return tags

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -150,3 +150,12 @@ def list_datahub_domains() -> list[str]:
         for domain in results["listDomains"]["domains"]
     ]
     return domains_list
+
+
+def get_tags(dbt_manifest_node: dict) -> list[str]:
+    """Resolve the tags to assign to nodes in datahub."""
+    tags = []
+    if "dc_display_in_catalogue" in dbt_manifest_node["tags"]:
+        tags += "dc_display_in_catalogue"
+    if dbt_manifest_node["resource_type"] == "seed":
+        tags += "dc_display_in_catalogue"

--- a/ingestion/transformers/assign_cadet_databases.py
+++ b/ingestion/transformers/assign_cadet_databases.py
@@ -64,7 +64,7 @@ class AssignCadetDatabases(DatasetTransformer, metaclass=ABCMeta):
         manifest = get_cadet_manifest(self.config.manifest_s3_uri)
         mappings = self._get_table_database_mappings(manifest)
 
-        logging.debug("Assigning databases to datasets")
+        logging.debug("Assigning datasets to databases")
         for dataset_urn in self.entity_map.keys():
             container_urn = mappings.get(dataset_urn)
             if not container_urn:
@@ -85,7 +85,7 @@ class AssignCadetDatabases(DatasetTransformer, metaclass=ABCMeta):
     def _get_table_database_mappings(self, manifest) -> Dict[str, str]:
         mappings = {}
         for node in manifest["nodes"]:
-            if manifest["nodes"][node]["resource_type"] == "model":
+            if manifest["nodes"][node]["resource_type"] in ["model", "seed"]:
                 fqn = manifest["nodes"][node]["fqn"]
                 if validate_fqn(fqn):
                     database, table_name = parse_database_and_table_names(

--- a/tests/data/manifest.json
+++ b/tests/data/manifest.json
@@ -71,12 +71,12 @@
             "resource_type": "model"
         },
         "seed.test_derived_tables.nope": {
-            "schema": "test_derived_tables_dev_dbt",
+            "schema": "ref_database",
             "fqn": [
-                "model",
-                "nope",
-                "test_derived_tables",
-                "table1"
+                "seed",
+                "General",
+                "ref_database",
+                "ref_database__postcodes"
             ],
             "tags": [
                 "weekly",
@@ -87,7 +87,7 @@
         "source.test_derived_tables.nope": {
             "schema": "test_derived_tables",
             "fqn": [
-                "model",
+                "source",
                 "nope",
                 "test_derived_tables",
                 "table1"

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -39,16 +39,14 @@ class TestCreateCadetDatabases:
             in self.results[8].metadata.aspect.domains
         )
 
-    def test_seeds_are_ingested(self):
-        dataset_urns = [result.metadata.entityUrn for result in self.results[-5:]]
-        expected_urn = builder.make_dataset_urn(
-            builder.make_data_platform_urn(platform="dbt"),
-            "cadet.awsdatacatalog.ref_database.postcodes"
-        )
-        assert expected_urn in dataset_urns
+    def test_seeds_are_tagged_to_display_in_catalogue(self):
+        seed_tag_event = self.results[34]
+        assert seed_tag_event.metadata.entityType == "dataset"
+        assert seed_tag_event.metadata.changeType == "UPSERT"
+        assert seed_tag_event.metadata.aspect.tags[0].tag == 'urn:li:tag:dc_display_in_catalogue'
 
     def test_datasets_are_assigned_to_domains(self):
         # This is the first event which should associate a dataset with a domain
         assert self.results[35].metadata.entityType == "dataset"
         assert self.results[35].metadata.changeType == "UPSERT"
-        assert self.results[35].metadata.aspect.domains
+        assert self.results[35].metadata.aspect.ASPECT_NAME == "domains"

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -39,8 +39,16 @@ class TestCreateCadetDatabases:
             in self.results[8].metadata.aspect.domains
         )
 
+    def test_seeds_are_ingested(self):
+        dataset_urns = [result.metadata.entityUrn for result in self.results[-5:]]
+        expected_urn = builder.make_dataset_urn(
+            builder.make_data_platform_urn(platform="dbt"),
+            "cadet.awsdatacatalog.ref_database.postcodes"
+        )
+        assert expected_urn in dataset_urns
+
     def test_datasets_are_assigned_to_domains(self):
-        # This is the first event which should associate a dataset with a database
-        assert self.results[28].metadata.entityType == "dataset"
-        assert self.results[28].metadata.changeType == "UPSERT"
-        assert self.results[28].metadata.aspect.domains
+        # This is the first event which should associate a dataset with a domain
+        assert self.results[35].metadata.entityType == "dataset"
+        assert self.results[35].metadata.changeType == "UPSERT"
+        assert self.results[35].metadata.aspect.domains

--- a/tests/test_ingestion_utils.py
+++ b/tests/test_ingestion_utils.py
@@ -42,8 +42,8 @@ with open("tests/data/manifest.json") as f:
         ),
         (
             test_manifest["nodes"]["seed.test_derived_tables.nope"],
-            "test_derived_tables_dev_dbt",
-            "table1",
+            "ref_database",
+            "postcodes",
         ),
     ],
 )


### PR DESCRIPTION
- Seeds will be not be assigned a domain unless they are associated with a domain from the models' domain grouping
- [Here's an example](https://dev.find-moj-data.service.justice.gov.uk/details/table/urn:li:dataset:(urn:li:dataPlatform:dbt,cadet.awsdatacatalog.lookup_offence_v2.offence_priority,PROD))
- We have ~57 seeds and seed databases