### PR TITLE
Dc 262 cadet database metadata ingest

### DIFF
--- a/ingestion/create_cadet_databases.yaml
+++ b/ingestion/create_cadet_databases.yaml
@@ -2,3 +2,4 @@ source:
   type: "ingestion.create_cadet_databases_source.source.CreateCadetDatabases"
   config:
     manifest_s3_uri: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/manifest.json"
+    database_metadata_s3_uri: "s3://mojap-derived-tables/prod/run_artefacts/latest/target/database_metadata.json"

--- a/ingestion/create_cadet_databases_source/config.py
+++ b/ingestion/create_cadet_databases_source/config.py
@@ -6,3 +6,6 @@ class CreateCadetDatabasesConfig(ConfigModel):
     manifest_s3_uri: str = Field(
         description="s3 path to dbt manifest json", default=None
     )
+    database_metadata_s3_uri: str = Field(
+        description="s3 path to database_metadata json", default=None
+    )

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -253,7 +253,7 @@ class CreateCadetDatabases(Source):
                     database, table = parse_database_and_table_names(
                         manifest["nodes"][node]
                     )
-                    domain = fqn[1]
+                    database_metadata_dict["domain"] = fqn[1]
                     database_mappings.add((database, database_metadata_tuple))
                     table_mappings.add(
                         (database, table, database_metadata_dict["domain"])

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -249,14 +249,15 @@ class CreateCadetDatabases(Source):
                     table_mappings.add(
                         (database, table, database_metadata_dict["domain"])
                     )
-                    if tag is not None:
-                        tags[database] = [tag]
+
                     database, table = parse_database_and_table_names(
                         manifest["nodes"][node]
                     )
                     domain = fqn[1]
-                    database_mappings.add((database, domain))
-                    table_mappings.add((database, table, domain))
+                    database_mappings.add((database, database_metadata_tuple))
+                    table_mappings.add(
+                        (database, table, database_metadata_dict["domain"])
+                    )
 
                     tags = get_tags(manifest["nodes"][node])
                     if tags:

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -16,15 +16,19 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 @report_time
-def get_cadet_manifest(manifest_s3_uri: str) -> Dict:
+def get_cadet_metadata_json(s3_uri: str) -> Dict:
+    """
+    Returns dict object containin metadata from the json file at the given s3 path.
+    Examples are the manifest file or the database_metadata file
+    """
     try:
         s3 = boto3.client("s3")
-        s3_parts = manifest_s3_uri.split("/")
+        s3_parts = s3_uri.split("/")
         bucket_name = s3_parts[2]
         file_key = "/".join(s3_parts[3:])
         response = s3.get_object(Bucket=bucket_name, Key=file_key)
         content = response["Body"].read().decode("utf-8")
-        manifest = json.loads(content, strict=False)
+        metadata = json.loads(content, strict=False)
     except NoCredentialsError:
         print("Credentials not available.")
         raise
@@ -40,7 +44,7 @@ def get_cadet_manifest(manifest_s3_uri: str) -> Dict:
         # Catch any other exceptions
         print(f"An error occurred: {str(e)}")
         raise
-    return manifest
+    return metadata
 
 
 def validate_fqn(fqn: list[str]) -> bool:

--- a/ingestion/transformers/assign_cadet_databases.py
+++ b/ingestion/transformers/assign_cadet_databases.py
@@ -13,7 +13,7 @@ from datahub.metadata.schema_classes import ContainerClass, MetadataChangePropos
 
 from ingestion.config import ENV, INSTANCE, PLATFORM
 from ingestion.ingestion_utils import (
-    get_cadet_manifest,
+    get_cadet_metadata_json,
     parse_database_and_table_names,
     validate_fqn,
 )
@@ -61,7 +61,7 @@ class AssignCadetDatabases(DatasetTransformer, metaclass=ABCMeta):
             Union[MetadataChangeProposalWrapper, MetadataChangeProposalClass]
         ] = []
 
-        manifest = get_cadet_manifest(self.config.manifest_s3_uri)
+        manifest = get_cadet_metadata_json(self.config.manifest_s3_uri)
         mappings = self._get_table_database_mappings(manifest)
 
         logging.debug("Assigning datasets to databases")

--- a/tests/data/database_metadata.json
+++ b/tests/data/database_metadata.json
@@ -1,0 +1,28 @@
+{
+    "databases": {
+        "prison_database": {
+            "description": "test db for prison",
+            "dc_owner": "some.team@justice.gov.uk",
+            "dc_slack_channel_name": "#ask-me",
+            "dc_slack_channel_url": "https://slack.com/1233",
+            "dc_readable_name": "Prison database",
+            "dc_access_requirements": "https://user-guidance.justice.gov.uk"
+        },
+        "probation_database": {
+            "description": "test db for probation",
+            "dc_owner": "some.one",
+            "dc_slack_channel_name": "#ask-me-again",
+            "dc_slack_channel_url": "https://slack.com/123",
+            "dc_readable_name": "Probation database",
+            "dc_access_requirements": "https://user-guidance.justice.gov.uk"
+        },
+        "hq_database": {
+            "description": "test db for hq",
+            "dc_owner": "",
+            "dc_slack_channel_name": "#ask-me-again",
+            "dc_slack_channel_url": "https://slack.com/123",
+            "dc_readable_name": "HQ database",
+            "dc_access_requirements": "https://user-guidance.justice.gov.uk"
+        }
+    }
+}

--- a/tests/test_assign_cadet_databases.py
+++ b/tests/test_assign_cadet_databases.py
@@ -30,7 +30,7 @@ class TestAssignCadetDatabasesTransformer:
             transformer_type=AssignCadetDatabases,
             aspect=models.ContainerClass(container=None),
             config={
-                "manifest_s3_uri": "s3://mojap-derived-tables/prod/run_artefacts/latest/target/manifest.json"
+                "manifest_s3_uri": "s3://test_bucket/prod/run_artefacts/latest/target/manifest.json",
             },
             pipeline_context=pipeline_context,
         )

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -23,7 +23,8 @@ class TestCreateCadetDatabases:
         source = CreateCadetDatabases(
             ctx=PipelineContext(run_id="domain-source-test"),
             config=CreateCadetDatabasesConfig(
-                manifest_s3_uri="s3://mojap-derived-tables/prod/run_artefacts/latest/target/manifest.json"
+                manifest_s3_uri="s3://test_bucket/prod/run_artefacts/latest/target/manifest.json",
+                database_metadata_s3_uri="s3://test_bucket/prod/run_artefacts/latest/target/database_metadata.json",
             ),
         )
         self.results = list(source.get_workunits())
@@ -38,6 +39,14 @@ class TestCreateCadetDatabases:
         domain_creation_events = self.results_by_aspect_type[DomainPropertiesClass]
         domains = [event.metadata.aspect.name for event in domain_creation_events]
         assert domains == ["Courts", "HQ", "Prison", "Probation"]
+
+        # test for user mce
+        user_creation_events = self.results[4:6]
+        user_urns = [
+            event.metadata.proposedSnapshot.urn for event in user_creation_events
+        ]
+        user_urns.sort()
+        assert user_urns == ["urn:li:corpuser:some.one", "urn:li:corpuser:some.team"]
 
         # Events are created for the following aspects per database:
         # create container, update status, add platform, add subtype, associate container with domain, add tags

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -99,6 +99,6 @@ class TestCreateCadetDatabases:
 
     def test_datasets_are_assigned_to_domains(self):
         # This is the first event which should associate a dataset with a domain
-        assert self.results[35].metadata.entityType == "dataset"
-        assert self.results[35].metadata.changeType == "UPSERT"
-        assert self.results[35].metadata.aspect.ASPECT_NAME == "domains"
+        assert self.results[39].metadata.entityType == "dataset"
+        assert self.results[39].metadata.changeType == "UPSERT"
+        assert self.results[39].metadata.aspect.ASPECT_NAME == "domains"


### PR DESCRIPTION
**This shouldn't be merged until the cadet PR is merged, there won't be a database_metadata.json file at the expected path until then.**

PR relates to issue #262 and will ingest database level metadata once the following PR in cadet is merged https://github.com/moj-analytical-services/create-a-derived-table/pull/2052

process is following:
- It looks for the database_metadata.json in s3 at given path (same folder as manifest)
- Uses that metadata to match to database entities tagged `dc_display_in_catalogue` inferred from manifest file
- Creates the owner in datahub.
- On database creation adds description, owner to their respective datahub properties and adds everything else as custom properties.

