### PR TITLE
fix: clear justice data charts before ingestion

### DIFF
--- a/.github/workflows/ingest-justice-data.yml
+++ b/.github/workflows/ingest-justice-data.yml
@@ -58,6 +58,13 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit != 'true'
       - run: poetry install --no-interaction
 
+      - name: clear existing justice data
+        env:
+          DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
+          DATAHUB_GMS_URL: ${{ vars.DATAHUB_GMS_URL }}
+          DATAHUB_TELEMETRY_ENABLED: false
+        run:  datahub delete --platform justice-data --hard
+
       - name: justice data datahub ingestion
         env:
           DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}


### PR DESCRIPTION
This is required to clear stale metadata from find-moj-data

Related to this bug issue https://github.com/ministryofjustice/find-moj-data/issues/842 but on closer inspection this was already handled by excluding the justice-in-numbers id. However ingestions prior to the implementation of the excluded ids meant that all those chart entities persisted in datahub.

Deleting all charts before re-ingesting will ensure the justice data is always current