### PR TITLE
Enable custom search and provide current master search configuration

### DIFF
--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -487,29 +487,12 @@ global:
                 score_mode: multiply
                 boost_mode: replace
 
-            # Test criteria for phrase with underscores only
-            # Contains quotes, is a single term with `_`, `.`, or `-` (normally consider for tokenization) then use exact match query
-            - queryRegex: >-
-                ^[a-zA-Z0-9]\S+[_.-]\S+[a-zA-Z0-9]$
-              simpleQuery: false
-              prefixMatchQuery: true
-              exactMatchQuery: false
-              functionScore:
-                functions:
-                  - filter:
-                      term:
-                        deprecated:
-                          value: true
-                    weight: 0.25
-                score_mode: multiply
-                boost_mode: multiply
-
             # Criteria for exact-match only
             # Contains quotes, is a single term with `_`, `.`, or `-` (normally consider for tokenization) then use exact match query
             - queryRegex: >-
                 ^["'].+["']$|^[a-zA-Z0-9]\S+[_.-]\S+[a-zA-Z0-9]$
               simpleQuery: false
-              prefixMatchQuery: true
+              prefixMatchQuery: false
               exactMatchQuery: true
               functionScore:
                 functions:

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -417,10 +417,107 @@ global:
         maxResult: 10000
 
       custom:
-        enabled: false
+        enabled: true
         # See documentation: https://datahubproject.io/docs/how/search/#customizing-search
         # default config: https://github.com/acryldata/datahub-helm/blob/master/charts/datahub/values.yaml#L481-L554
+        config:
+          # Notes:
+          #
+          # First match wins
+          #
+          # queryRegex = Java regex syntax
+          #
+          # functionScores - See the following for function score syntax
+          # https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-function-score-query.html
 
+          queryConfigurations:
+            # Select */explore all
+            # Attempt to rank active incidents at the top followed by enrichment factors
+            - queryRegex: "[*]|"
+              simpleQuery: false
+              prefixMatchQuery: false
+              exactMatchQuery: false
+              functionScore:
+                functions:
+                  - filter:
+                      term:
+                        hasActiveIncidents:
+                          value: true
+                    weight: 2.0
+                  - filter:
+                      term:
+                        hasDescription:
+                          value: true
+                    weight: 1.25
+                  - filter:
+                      term:
+                        hasOwners:
+                          value: true
+                    weight: 1.25
+                  - filter:
+                      term:
+                        hasDomain:
+                          value: true
+                    weight: 1.1
+                  - filter:
+                      term:
+                        hasGlossaryTerms:
+                          value: true
+                    weight: 1.1
+                  - filter:
+                      term:
+                        hasTags:
+                          value: true
+                    weight: 1.1
+                  - filter:
+                      term:
+                        hasRowCount:
+                          value: true
+                    weight: 1.05
+                  - filter:
+                      term:
+                        hasColumnCount:
+                          value: true
+                    weight: 1.05
+                  - filter:
+                      term:
+                        deprecated:
+                          value: true
+                    weight: 0.25
+                score_mode: multiply
+                boost_mode: replace
+
+            # Criteria for exact-match only
+            # Contains quotes, is a single term with `_`, `.`, or `-` (normally consider for tokenization) then use exact match query
+            - queryRegex: >-
+                ^["'].+["']$|^[a-zA-Z0-9]\S+[_.-]\S+[a-zA-Z0-9]$
+              simpleQuery: false
+              prefixMatchQuery: true
+              exactMatchQuery: true
+              functionScore:
+                functions:
+                  - filter:
+                      term:
+                        deprecated:
+                          value: true
+                    weight: 0.25
+                score_mode: multiply
+                boost_mode: multiply
+
+            # default
+            - queryRegex: .*
+              simpleQuery: true
+              prefixMatchQuery: true
+              exactMatchQuery: true
+              functionScore:
+                functions:
+                  - filter:
+                      term:
+                        deprecated:
+                          value: true
+                    weight: 0.25
+                score_mode: multiply
+                boost_mode: multiply
   kafka:
     bootstrap:
       server: "prerequisites-kafka:9092"
@@ -460,22 +557,22 @@ global:
       hooks:
         siblings:
           enabled: true
-          consumerGroupSuffix: ''
+          consumerGroupSuffix: ""
         updateIndices:
           enabled: true
-          consumerGroupSuffix: ''
+          consumerGroupSuffix: ""
         ingestionScheduler:
           enabled: true
-          consumerGroupSuffix: ''
+          consumerGroupSuffix: ""
         incidents:
           enabled: true
-          consumerGroupSuffix: ''
+          consumerGroupSuffix: ""
         entityChangeEvents:
           enabled: true
-          consumerGroupSuffix: ''
+          consumerGroupSuffix: ""
         forms:
           enabled: true
-          consumerGroupSuffix: ''
+          consumerGroupSuffix: ""
 
   sql:
     datasource:

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -487,6 +487,23 @@ global:
                 score_mode: multiply
                 boost_mode: replace
 
+            # Test criteria for phrase with underscores only
+            # Contains quotes, is a single term with `_`, `.`, or `-` (normally consider for tokenization) then use exact match query
+            - queryRegex: >-
+                ^[a-zA-Z0-9]\S+[_.-]\S+[a-zA-Z0-9]$
+              simpleQuery: false
+              prefixMatchQuery: true
+              exactMatchQuery: false
+              functionScore:
+                functions:
+                  - filter:
+                      term:
+                        deprecated:
+                          value: true
+                    weight: 0.25
+                score_mode: multiply
+                boost_mode: multiply
+
             # Criteria for exact-match only
             # Contains quotes, is a single term with `_`, `.`, or `-` (normally consider for tokenization) then use exact match query
             - queryRegex: >-


### PR DESCRIPTION
- Enables custom a search configuration through the use of helm variables as mentioned [here](https://github.com/datahub-project/datahub/issues/11398#issuecomment-2365323473)
- Custom search mimics the current release behaviour
- Behaviour can be adapted once we have discussed the current search pitfalls