### PR TITLE
Change IRSA_SA prefix

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -160,7 +160,7 @@ jobs:
         env:
           APP_SHORT_HOST: ${{ env.APP_SHORT_HOST }}
           CHART_VERSION: ${{ inputs.datahub_helm_version }}
-          IRSA_SA: data-platform-${{ inputs.env }}
+          IRSA_SA: data-catalogue-${{ inputs.env }}
           OPENSEARCH_PROXY_HOST: ${{ secrets.OPENSEARCH_PROXY_HOST }}
           POSTGRES_CLIENT_HOST: ${{ secrets.postgres_client_host }}
           POSTGRES_HOST: ${{ secrets.postgres_host }}


### PR DESCRIPTION
Last week I changed the owning team of our cloud platform infra from data-platform to data-catalogue. (https://github.com/ministryofjustice/cloud-platform-environments/pull/26463)

This seems to have had a side effect of changing the name of the service account from `data-platform-*` to `data-catalogue-*`

This prevents the datahub actions deployment from creating any pods.