### PR TITLE
fix: do not skip over any nodes when looking for database metadata

### DIFF
--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -232,21 +232,13 @@ class CreateCadetDatabases(Source):
                         manifest["nodes"][node]
                     )
                     database_metadata_dict = {}
-                    tag = (
-                        "dc_display_in_catalogue"
-                        if "dc_display_in_catalogue" in manifest["nodes"][node]["tags"]
-                        else None
-                    )
 
-                    if tag == "dc_display_in_catalogue":
-                        try:
-                            database_metadata_dict = databases_metadata["databases"][
-                                database
-                            ]
-                        except KeyError:
-                            logging.warning(
-                                f"{database} - has no database level metadata"
-                            )
+                    try:
+                        database_metadata_dict = databases_metadata["databases"][
+                            database
+                        ]
+                    except KeyError:
+                        logging.debug(f"{database} - has no database level metadata")
 
                     database_metadata_dict["domain"] = fqn[1]
                     database_metadata_tuple = tuple(database_metadata_dict.items())


### PR DESCRIPTION
Noticed a bug that had crept through - In short the code was only trying to get metadata from the database metadata dict if the table's node was tagged to display. This had the unwanted impact of sometimes creating two databases entries in the returned set when a database had tables tagged both to display and not. One element with additional metadata and one without. 

This is the cause of some metadata not coming through at the database level as it gets written to datahub and then later is wiped by the element in the set without the additional metadata