### PR TITLE
fix: cadet db ingestion to now remove display tag when not needed

### DIFF
--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -119,7 +119,7 @@ class CreateCadetDatabases(Source):
             db_meta_dict = dict(database_metadata)
             domain_name = format_domain_name(db_meta_dict["domain"])
             domain_urn = mce_builder.make_domain_urn(domain=domain_name)
-            display_tag = display_tags.get(database_name)
+            display_tag = display_tags.get(database_name, ["dc_cadet"])
 
             if not db_meta_dict.get("dc_owner", "") == "":
                 owner_urn = mce_builder.make_user_urn(


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/find-moj-data/issues/962

workaround similar to the other tags we couldnt remove

a blank list gets skipped so need to default to `dc_cadet` when the `get()` misses