### PR TITLE
Introduce "data custodian ownership type", and use it in all ingestions

### DIFF
--- a/.github/workflows/ingest-dev.yml
+++ b/.github/workflows/ingest-dev.yml
@@ -6,6 +6,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  ingest-ownership-types-dev:
+    uses: ./.github/workflows/ingest-ownership-types.yml
+    with:
+      ENVIRONMENT: dev
+    secrets:
+      DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
+      SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}
   ingest-cadet-dev:
     uses: ./.github/workflows/ingest-cadet-metadata.yml
     with:

--- a/.github/workflows/ingest-justice-data.yml
+++ b/.github/workflows/ingest-justice-data.yml
@@ -76,7 +76,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.27.0
         if: job.status == 'failure'
         with:
-          channel-id: "C071VNHPUHZ"
           payload: |
             {
                 "text": ":warning: Unable to ingest Justice Data metadata on ${{inputs.ENVIRONMENT}}!",

--- a/.github/workflows/ingest-ownership-types.yml
+++ b/.github/workflows/ingest-ownership-types.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Notify on failure
         uses: slackapi/slack-github-action@v1.27.0
-        if: job.status == 'failure'
+        if: failure()
         with:
           channel-id: "C071VNHPUHZ"
           payload: |

--- a/.github/workflows/ingest-ownership-types.yml
+++ b/.github/workflows/ingest-ownership-types.yml
@@ -64,7 +64,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.27.0
         if: failure()
         with:
-          channel-id: "C071VNHPUHZ"
           payload: |
             {
                 "text": ":warning: Unable to ingest ownership types metadata on ${{inputs.ENVIRONMENT}}!",

--- a/.github/workflows/ingest-ownership-types.yml
+++ b/.github/workflows/ingest-ownership-types.yml
@@ -1,0 +1,83 @@
+name: "Ingest metadata from ownership types public api"
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      ENVIRONMENT:
+        description: "Environment to use for secrets"
+        required: true
+        type: string
+    secrets:
+      DATAHUB_GMS_TOKEN:
+        description: "API Key for datahub GMS"
+        required: true
+      SLACK_ALERT_WEBHOOK:
+        description: "Webhook for posting alerts to the team"
+        required: true
+
+jobs:
+  datahub-ingest-ownership-types:
+    environment: ${{ inputs.ENVIRONMENT }}
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "ENVIRONMENT=${{inputs.ENVIRONMENT}}; URL=${{vars.DATAHUB_GMS_URL}}"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: cache poetry install
+        uses: actions/cache@v4
+        with:
+          path: ~/.local
+          key: poetry-1.7.1-0
+
+      - uses: snok/install-poetry@v1
+        with:
+          version: 1.7.1
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: cache deps
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: pydeps-${{ hashFiles('**/poetry.lock') }}
+      - run: poetry install --no-interaction --no-root
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+      - run: poetry install --no-interaction
+
+      - name: ownership types ingestion
+        env:
+          DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
+          DATAHUB_GMS_URL: ${{ vars.DATAHUB_GMS_URL }}
+          DATAHUB_TELEMETRY_ENABLED: false
+        run: time poetry run datahub ingest -c ingestion/create_custom_ownership_types.yaml
+
+      - name: Notify on failure
+        uses: slackapi/slack-github-action@v1.27.0
+        if: job.status == 'failure'
+        with:
+          channel-id: "C071VNHPUHZ"
+          payload: |
+            {
+                "text": ":warning: Unable to ingest ownership types metadata on ${{inputs.ENVIRONMENT}}!",
+                "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                    "type": "mrkdwn",
+                    "text": "GitHub Action run result: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                }
+                ]
+            }
+
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -51,12 +51,12 @@ source:
     strip_user_ids_from_email: false
     tag_prefix: ""
     meta_mapping:
-      dc_owner:
-        match: '.*'
-        operation: 'add_owner'
+      dc_data_custodian:
+        match: ".*"
+        operation: "add_owner"
         config:
           owner_type: user
-          owner_category: DATAOWNER
+          owner_category: urn:li:ownershipType:data_custodian
 
 transformers:
   - type: "ingestion.transformers.assign_cadet_databases.AssignCadetDatabases"

--- a/ingestion/create_custom_ownership_types.yaml
+++ b/ingestion/create_custom_ownership_types.yaml
@@ -1,0 +1,5 @@
+# see https://datahubproject.io/docs/generated/ingestion/sources/file for complete documentation
+source:
+  type: "file"
+  config:
+    path: "ingestion/ownership_types/ownership_types.json"

--- a/ingestion/justice_data_source/source.py
+++ b/ingestion/justice_data_source/source.py
@@ -177,7 +177,13 @@ class JusticeDataAPISource(TestableSource):
         # add chart ownership
         owner_urn = builder.make_group_urn(chart_data["owner_email"].split("@")[0])
         chart_owner = OwnershipClass(
-            owners=[OwnerClass(owner=owner_urn, type="DATAOWNER")]
+            owners=[
+                OwnerClass(
+                    owner=owner_urn,
+                    type="CUSTOM",
+                    typeUrn="urn:li:ownershipType:data_custodian",
+                )
+            ]
         )
         chart_snapshot.aspects.append(chart_owner)
 

--- a/ingestion/ownership_types/ownership_types.json
+++ b/ingestion/ownership_types/ownership_types.json
@@ -1,0 +1,14 @@
+[
+    {
+      "auditHeader":null,
+      "entityType":"ownershipType",
+      "entityUrn": "urn:li:ownershipType:data_custodian",
+      "changeType":"UPSERT",
+      "aspectName":"ownershipTypeInfo",
+      "aspect":{
+        "value":"{\"name\": \"Data Custodian\", \"description\": \"Responsible for the capture, storage, and disposal of data as per the Data owner and Data steward's requirements, and within the limits of data quality and security limitations.\", \"created\": {\"time\": 1729781312000,  \"actor\": \"urn:li:corpuser:datahub\",  \"impersonator\": null},\n\"lastModified\": {\"time\": 1729781312000,  \"actor\": \"urn:li:corpuser:datahub\",  \"impersonator\": null}}",
+        "contentType":"application/json"
+      },
+      "systemMetadata":null
+    }
+]


### PR DESCRIPTION
https://github.com/ministryofjustice/find-moj-data/issues/950

The data custodian is the role we actually want to show in Find MoJ data.

This PR ingestions a custom ownership type, so that we can explicitly represent this role in Datahub.

In CaDeT, we will introduce dc_data_custodian as a separate meta field for clarity, rather than reusing dc_owner.
This needs to be rolled out in conjunction with changes to the metadata in CaDeT.

In Justice Data, map `owner_email` to the custodian, not the data owner.