### PR TITLE
Update postgresqlSetupJob to the latest tag

### DIFF
--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -202,7 +202,7 @@ postgresqlSetupJob:
   image:
     repository: acryldata/datahub-postgres-setup
     # tag: "v0.11.0" # defaults to .global.datahub.version
-    tag: v0.14.0.2 # Workaround for no tag existing in v0.14.1 release
+    tag: 6a165a8 # Workaround for no tag existing in v0.14.1 release
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
No official tag was published for the v0.14.1 release https://github.com/datahub-project/datahub/issues/11655

However, I suspect that leaving this at the previous version may have been the wrong thing to do, as we are now experiencing compatability issues with the python package, similar to
https://github.com/datahub-project/datahub/issues/11679

I'm going to try updating to the latest tag and see if it resolves the comptability issues on v0.14.1.5 of the python package.