### PR TITLE
Dc 325 create db from dbt sources

### DIFF
--- a/.github/workflows/ingest-glue-data.yml
+++ b/.github/workflows/ingest-glue-data.yml
@@ -76,8 +76,8 @@ jobs:
         run: |
           time poetry run datahub ingest -c ingestion/glue_sop.yaml
           time poetry run datahub ingest -c ingestion/glue_contracts.yaml
-          time poetry run datahub ingest -c ingestion/courts_criminal.yaml
-          time poetry run datahub ingest -c ingestion/courts_family.yaml
+          time poetry run datahub ingest -c ingestion/glue_courts_criminal.yaml
+          time poetry run datahub ingest -c ingestion/glue_courts_family.yaml
 
       - name: Notify on failure
         uses: slackapi/slack-github-action@v1.27.0

--- a/.github/workflows/ingest-glue-data.yml
+++ b/.github/workflows/ingest-glue-data.yml
@@ -76,6 +76,8 @@ jobs:
         run: |
           time poetry run datahub ingest -c ingestion/glue_sop.yaml
           time poetry run datahub ingest -c ingestion/glue_contracts.yaml
+          time poetry run datahub ingest -c ingestion/courts_criminal.yaml
+          time poetry run datahub ingest -c ingestion/courts_family.yaml
 
       - name: Notify on failure
         uses: slackapi/slack-github-action@v1.27.0

--- a/ingestion/glue_courts_criminal.yaml
+++ b/ingestion/glue_courts_criminal.yaml
@@ -4,10 +4,7 @@ source:
     aws_region: "eu-west-1"
     database_pattern:
       allow: [
-        "sop_transformed_v1_ac$",
-        "sop_derived$",
-        "sop_lookups$",
-        "sop_preprocessed$"
+        "mags_curated_v3$",
       ]
     extract_owners: False
     extract_transforms: False
@@ -19,16 +16,16 @@ transformers:
         - "urn:li:tag:dc_display_in_catalogue"
   - type: "ingestion.transformers.enrich_container_transformer.EnrichContainerTransformer"
     config:
-      data_custodian: "urn:li:corpuser:holly.furniss"
-      domain: urn:li:domain:People
+      data_custodian: "urn:li:corpuser:Gustav.Moller"
+      domain: urn:li:domain:Courts
   - type: "simple_add_dataset_domain"
     config:
       semantics: OVERWRITE
       domains:
-        - urn:li:domain:People
+        - urn:li:domain:Courts
   - type: "simple_add_dataset_ownership"
     config:
       semantics: OVERWRITE
       ownership_type: "DATAOWNER"
       owner_urns:
-        - "urn:li:corpuser:holly.furniss"
+        - "urn:li:corpuser:Gustav.Moller"

--- a/ingestion/glue_courts_family.yaml
+++ b/ingestion/glue_courts_family.yaml
@@ -4,10 +4,8 @@ source:
     aws_region: "eu-west-1"
     database_pattern:
       allow: [
-        "sop_transformed_v1_ac$",
-        "sop_derived$",
-        "sop_lookups$",
-        "sop_preprocessed$"
+        "familyman_live_v4$",
+        "familyman_derived_live_v4$"
       ]
     extract_owners: False
     extract_transforms: False
@@ -19,16 +17,16 @@ transformers:
         - "urn:li:tag:dc_display_in_catalogue"
   - type: "ingestion.transformers.enrich_container_transformer.EnrichContainerTransformer"
     config:
-      data_custodian: "urn:li:corpuser:holly.furniss"
-      domain: urn:li:domain:People
+      data_custodian: "urn:li:corpuser:James.Baker2"
+      domain: urn:li:domain:Courts
   - type: "simple_add_dataset_domain"
     config:
       semantics: OVERWRITE
       domains:
-        - urn:li:domain:People
+        - urn:li:domain:Courts
   - type: "simple_add_dataset_ownership"
     config:
       semantics: OVERWRITE
       ownership_type: "DATAOWNER"
       owner_urns:
-        - "urn:li:corpuser:holly.furniss"
+        - "urn:li:corpuser:James.Baker2"


### PR DESCRIPTION
This PR adds in some additional databases from glue. 

These are listed as sources in cadet but because of issues highlighted here https://github.com/ministryofjustice/data-catalogue/issues/325#issuecomment-2467661352, we've opted to ingest these direct from glue and not present any of the sources from dbt (cadet) in find-moj-data