### PR TITLE
Add metadata to Justice Data ingestion source

### DIFF
--- a/ingestion/justice_data_source/api_client.py
+++ b/ingestion/justice_data_source/api_client.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from datetime import datetime
 
 import requests
@@ -12,9 +11,9 @@ class JusticeDataAPIClient:
     def __init__(self, base_url, default_owner_email):
         self.session = requests.Session()
         self.base_url = base_url
-        self.publication_details: list[dict] = self.session.get(
-            os.path.join(self.base_url, "publications")
-        ).json()
+        self.publication_details: dict[str, dict] = {
+            pub["id"]: pub for pub in self.list_publications()
+        }
         self.default_owner_email = default_owner_email
         self._id_to_domain_mapping = ID_TO_DOMAIN_MAPPING
 
@@ -39,6 +38,10 @@ class JusticeDataAPIClient:
             if id in exclude_id_list:
                 continue
 
+            if current.get("permalink") is None:
+                # Skip anything without a permalink, e.g. jin-court-capacity-subhead
+                continue
+
             if self._id_to_domain_mapping.get(id):
                 domain = format_domain_name(self._id_to_domain_mapping.get(id, ""))
             elif current.get("domain"):
@@ -56,15 +59,9 @@ class JusticeDataAPIClient:
                 last_updated, refresh_frequency, owner_email = (
                     self._get_publication_metadata(publication_id)
                 )
-                # datahub requires last updated to be an int or None if not known
-                current["last_updated_timestamp"] = (
-                    int(last_updated) if last_updated else None
-                )
-                # This is loaded as a custom property in datahub and so needs to be set as a string (even if empty)
-                current["refresh_frequency"] = (
-                    refresh_frequency if refresh_frequency else ""
-                )
 
+                current["last_updated_timestamp"] = last_updated
+                current["refresh_frequency"] = refresh_frequency
                 current["owner_email"] = owner_email
             else:
                 current["owner_email"] = self.default_owner_email
@@ -82,38 +79,33 @@ class JusticeDataAPIClient:
 
     def _get_publication_metadata(
         self, id: str
-    ) -> tuple[float | None, str | None, str]:
+    ) -> tuple[datetime | None, str | None, str]:
         """
         returns tuple of (last_updated, refresh_frequency, owner_email), the current published date
         (as a timestamp), publication frequency and owner email for the source publication of
         the chart id given as an input
         """
-        last_updated_timestamp, refresh_frequency, owner_email = (
-            None,
-            None,
-            self.default_owner_email,
-        )
-        for publication in self.publication_details:
-            if publication.get("id") == id:
-                refresh_frequency = publication.get("frequency")
-                try:
-                    last_updated_timestamp = datetime.strptime(
-                        publication.get("currentPublishDate", ""), "%d %B %Y"
-                    ).timestamp()
-                except (ValueError, TypeError) as e:
-                    logging.warning(
-                        f"Chart with id: {id}, missing valid currentPublishDate. Error: {e}"
-                    )
-                    last_updated_timestamp = None
+        publication = self.publication_details.get(id)
+        if not publication:
+            return (None, None, self.default_owner_email)
 
-                owner_email = publication.get("ownerEmail", self.default_owner_email)
+        refresh_frequency = publication.get("frequency")
+        try:
+            current_publish_date = datetime.strptime(
+                publication.get("currentPublishDate", ""), "%d %B %Y"
+            )
+        except (ValueError, TypeError) as e:
+            logging.warning(
+                f"Chart with id: {id}, missing valid currentPublishDate. Error: {e}"
+            )
+            current_publish_date = None
 
-                if owner_email is None:
-                    owner_email = self.default_owner_email
+        owner_email = publication.get("ownerEmail", self.default_owner_email)
 
-                break
+        if owner_email is None:
+            owner_email = self.default_owner_email
 
-        return last_updated_timestamp, refresh_frequency, owner_email
+        return current_publish_date, refresh_frequency, owner_email
 
     def validate_domains(self, datahub_domains) -> bool:
         for domain in set(self._id_to_domain_mapping.values()):

--- a/ingestion/justice_data_source/api_client.py
+++ b/ingestion/justice_data_source/api_client.py
@@ -17,7 +17,7 @@ class JusticeDataAPIClient:
         self.default_owner_email = default_owner_email
         self._id_to_domain_mapping = ID_TO_DOMAIN_MAPPING
 
-    def list_publications(self):
+    def list_publications(self) -> dict:
         """
         Return a list of publications
         """
@@ -40,6 +40,7 @@ class JusticeDataAPIClient:
 
             if current.get("permalink") is None:
                 # Skip anything without a permalink, e.g. jin-court-capacity-subhead
+                logging.info(f"{id=} has no permalink and will be skipped.")
                 continue
 
             if self._id_to_domain_mapping.get(id):

--- a/ingestion/justice_data_source/api_client.py
+++ b/ingestion/justice_data_source/api_client.py
@@ -18,6 +18,12 @@ class JusticeDataAPIClient:
         self.default_owner_email = default_owner_email
         self._id_to_domain_mapping = ID_TO_DOMAIN_MAPPING
 
+    def list_publications(self):
+        """
+        Return a list of publications
+        """
+        return self.session.get(self.base_url + "/publications").json()
+
     def list_all(self, exclude_id_list: list = []):
         """
         Traverse the metadata graph and return only leaf nodes.

--- a/tests/api_client_test.py
+++ b/tests/api_client_test.py
@@ -179,3 +179,56 @@ def test_validate_domains(
             client.validate_domains(datahub_domain_list)
     else:
         assert client.validate_domains(datahub_domain_list)
+
+
+def test_list_publications(client):
+    with vcr.use_cassette(
+        "tests/fixtures/vcr_cassettes/fetch_justice_data_publications.yaml"
+    ):
+        assert client.list_publications()[:3] == [
+            {
+                "id": "courts-civil",
+                "name": "Civil justice statistics",
+                "indexUri": "https://www.gov.uk/government/collections/civil-justice-statistics-quarterly",
+                "frequency": "Quarterly",
+                "source": "MOJ",
+                "documentType": "Accredited official statistics",
+                "description": "Volume of civil and judicial review cases dealt with by the courts over time and the overall timeliness of these cases. ",
+                "ownerEmail": "CAJS@justice.gov.uk",
+                "currentPublishDate": "5 September 2024",
+                "currentPublishDateAsDate": None,
+                "nextPublishDate": "5 December 2024 9:30am",
+                "nextPublishDateAsDateTime": "2024-12-05T09:30:00Z",
+                "sourceName": "Ministry of Justice",
+            },
+            {
+                "id": "community-performance",
+                "name": "Community performance annual",
+                "indexUri": "https://www.gov.uk/government/collections/prison-and-probation-trusts-performance-statistics#community-performance-statistics",
+                "frequency": "Annual",
+                "source": "MOJ",
+                "documentType": "Official Statistics",
+                "description": "An annual release of performance statistics for the Probation Service, incorporating Probation Service and Commissioned Rehabilitative Services performance.",
+                "ownerEmail": "communityperformanceenquiries@justice.gov.uk",
+                "currentPublishDate": "25 July 2024",
+                "currentPublishDateAsDate": "2024-07-25T00:00:00+00:00",
+                "nextPublishDate": None,
+                "nextPublishDateAsDateTime": None,
+                "sourceName": "Ministry of Justice",
+            },
+            {
+                "id": "ons-crime",
+                "name": "Crime in England and Wales",
+                "indexUri": "https://www.ons.gov.uk/peoplepopulationandcommunity/crimeandjustice/datasets/crimeinenglandandwalesappendixtables",
+                "frequency": "Quarterly",
+                "source": "ONS",
+                "documentType": "Official Statistics",
+                "description": "Crime against households and adults using data from\xa0police recorded crime and the Crime Survey for England and Wales.",
+                "ownerEmail": "crimestatistics@ons.gov.uk",
+                "currentPublishDate": "24 October 2024",
+                "currentPublishDateAsDate": "2024-10-24T00:00:00+00:00",
+                "nextPublishDate": None,
+                "nextPublishDateAsDateTime": None,
+                "sourceName": "Office of National Statistics",
+            },
+        ]

--- a/tests/api_client_test.py
+++ b/tests/api_client_test.py
@@ -135,7 +135,7 @@ def test_get_publication_metadata(client, default_owner_email):
         "ons-crime2",
         "ons-crime3",
     ]
-    client.publication_details = test_published_details
+    client.publication_details = {pub["id"]: pub for pub in test_published_details}
     for i, id in enumerate(ids):
         last_updated, refresh_frequency, owner_email = client._get_publication_metadata(
             id
@@ -144,7 +144,7 @@ def test_get_publication_metadata(client, default_owner_email):
             expected_updated_timestamp = datetime.strptime(
                 test_published_details[i].get("currentPublishDate"),
                 "%d %B %Y",
-            ).timestamp()
+            )
         else:
             expected_updated_timestamp = None
         assert last_updated == expected_updated_timestamp

--- a/tests/fixtures/vcr_cassettes/fetch_justice_data_publications.yaml
+++ b/tests/fixtures/vcr_cassettes/fetch_justice_data_publications.yaml
@@ -1,0 +1,173 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://data.justice.gov.uk/api/publications
+  response:
+    body:
+      string: "[{\"id\":\"courts-civil\",\"name\":\"Civil justice statistics\",\"indexUri\":\"https://www.gov.uk/government/collections/civil-justice-statistics-quarterly\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Accredited
+        official statistics\",\"description\":\"Volume of civil and judicial review
+        cases dealt with by the courts over time and the overall timeliness of these
+        cases. \",\"ownerEmail\":\"CAJS@justice.gov.uk\",\"currentPublishDate\":\"5
+        September 2024\",\"currentPublishDateAsDate\":null,\"nextPublishDate\":\"5
+        December 2024 9:30am\",\"nextPublishDateAsDateTime\":\"2024-12-05T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"community-performance\",\"name\":\"Community performance
+        annual\",\"indexUri\":\"https://www.gov.uk/government/collections/prison-and-probation-trusts-performance-statistics#community-performance-statistics\",\"frequency\":\"Annual\",\"source\":\"MOJ\",\"documentType\":\"Official
+        Statistics\",\"description\":\"An annual release of performance statistics
+        for the Probation Service, incorporating Probation Service and Commissioned
+        Rehabilitative Services performance.\",\"ownerEmail\":\"communityperformanceenquiries@justice.gov.uk\",\"currentPublishDate\":\"25
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-25T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"ons-crime\",\"name\":\"Crime in England and Wales\",\"indexUri\":\"https://www.ons.gov.uk/peoplepopulationandcommunity/crimeandjustice/datasets/crimeinenglandandwalesappendixtables\",\"frequency\":\"Quarterly\",\"source\":\"ONS\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Crime against households and adults using data
+        from\\u00A0police recorded crime and the Crime Survey for England and Wales.\",\"ownerEmail\":\"crimestatistics@ons.gov.uk\",\"currentPublishDate\":\"24
+        October 2024\",\"currentPublishDateAsDate\":\"2024-10-24T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Office
+        of National Statistics\"},{\"id\":\"crime-outcomes\",\"name\":\"Crime outcomes
+        in England and Wales\",\"indexUri\":\"https://www.gov.uk/government/collections/crime-outcomes-in-england-and-wales-statistics\",\"frequency\":\"Annual\",\"source\":\"HO\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Outcomes assigned to offences recorded to June
+        2023 and the total number of outcomes recorded, by outcome type and offence
+        type.\",\"ownerEmail\":\"crimeandpolicestats@homeoffice.gov.uk\",\"currentPublishDate\":\"24
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-24T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Home
+        Office\"},{\"id\":\"courts-criminal\",\"name\":\"Criminal court statistics
+        quarterly\",\"indexUri\":\"https://www.gov.uk/government/collections/criminal-court-statistics\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Accredited
+        official statistics\",\"description\":\"Type and volume of cases received
+        and processed through the criminal court system of England and Wales, including
+        statistics on case timeliness. Also includes statistics on the use of language
+        interpreter and translation ser\u2026\",\"ownerEmail\":\"criminal_court_sta@justice.gov.uk\",\"currentPublishDate\":\"28
+        March 2024\",\"currentPublishDateAsDate\":\"2024-03-28T00:00:00+00:00\",\"nextPublishDate\":\"19
+        December 2024 9:30am\",\"nextPublishDateAsDateTime\":\"2024-12-19T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"cjs-statistics\",\"name\":\"Criminal justice system
+        statistics quarterly\",\"indexUri\":\"https://www.gov.uk/government/collections/criminal-justice-statistics-quarterly\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Accredited
+        official statistics\",\"description\":\"Overview of trends in the use of out
+        of court disposals, defendants prosecuted, offenders convicted, remand and
+        sentencing decisions in England and Wales.\",\"ownerEmail\":\"CJS_Statistics@justice.gov.uk\",\"currentPublishDate\":\"15
+        August 2024\",\"currentPublishDateAsDate\":\"2024-08-15T00:00:00+00:00\",\"nextPublishDate\":\"21
+        November 2024 9:30am\",\"nextPublishDateAsDateTime\":\"2024-11-21T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"electronic-monitoring-performance\",\"name\":\"Electronic
+        Monitoring Statistics Annual Publication\",\"indexUri\":\"https://www.gov.uk/government/collections/electronic-monitoring-publication\",\"frequency\":\"Annual\",\"source\":\"MOJ\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Covers the use and delivery of electronic tags,
+        including location monitoring tags and alcohol monitoring tags, for England
+        and Wales.\",\"ownerEmail\":\"ppas_statistics@justice.gov.uk\",\"currentPublishDate\":\"18
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-18T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"electronic-monitoring\",\"name\":\"Electronic Monitoring
+        Statistics Publication\",\"indexUri\":\"https://www.gov.uk/government/collections/electronic-monitoring-publication\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Covers the use and delivery of electronic tags,
+        including location monitoring tags and alcohol monitoring tags, for England
+        and Wales.\",\"ownerEmail\":\"ppas_statistics@justice.gov.uk\",\"currentPublishDate\":\"18
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-18T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"courts-family\",\"name\":\"Family court statistics
+        quarterly\",\"indexUri\":\"https://www.gov.uk/government/collections/family-court-statistics-quarterly\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Accredited
+        official statistics\",\"description\":\"Volume of cases dealt with by family
+        courts over time, with statistics also broken down for the main types of case
+        involved. Includes data on Children Act cases (both public and private law),
+        Matrimonial matters, Domestic Vi\u2026\",\"ownerEmail\":\"familycourt.statistics@justice.gov.uk\",\"currentPublishDate\":\"26
+        September 2024\",\"currentPublishDateAsDate\":\"2024-09-26T00:00:00+00:00\",\"nextPublishDate\":\"19
+        December 2024 9:30am\",\"nextPublishDateAsDateTime\":\"2024-12-19T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"hmpps-workforce\",\"name\":\"HM Prison & Probation
+        Service workforce quarterly\",\"indexUri\":\"https://www.gov.uk/government/collections/national-offender-management-service-workforce-statistics\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Staffing numbers of directly employed staff
+        of the HM Prison and Probation Service.\",\"ownerEmail\":\"robert.hartley@justice.gov.uk\",\"currentPublishDate\":\"17
+        August 2023\",\"currentPublishDateAsDate\":\"2023-08-17T00:00:00+00:00\",\"nextPublishDate\":\"21
+        November 2024 9:30am\",\"nextPublishDateAsDateTime\":\"2024-11-21T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"hmpps-annual-digest\",\"name\":\"HM Prison and Probation
+        Service annual digest\",\"indexUri\":\"https://www.gov.uk/government/statistics/hmpps-annual-digest-april-2023-to-march-2024\",\"frequency\":\"Annual\",\"source\":\"MOJ\",\"documentType\":null,\"description\":\"Range
+        of detailed statistics and measures for prisons and probation\",\"ownerEmail\":\"SUEPer_Stats@justice.gov.uk\",\"currentPublishDate\":\"25
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-25T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"legal-aid-statistics\",\"name\":\"Legal aid statistics\",\"indexUri\":\"https://www.gov.uk/government/collections/legal-aid-statistics\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Accredited
+        official statistics\",\"description\":\"Activity in the legal aid system for
+        England and Wales, including criminal and civil legal aid, family mediation,
+        providers of legal aid, client characteristics and Central Funds payments.\\r\\n\",\"ownerEmail\":\"statistics@justice.gov.uk\",\"currentPublishDate\":\"26
+        September 2024\",\"currentPublishDateAsDate\":\"2024-09-26T00:00:00+00:00\",\"nextPublishDate\":\"19
+        December 2024 9:30am\",\"nextPublishDateAsDateTime\":\"2024-12-19T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"community-accommodation-management\",\"name\":\"Offender
+        accommodation outcomes\",\"indexUri\":\"https://www.gov.uk/government/collections/offender-accommodation-outcome-statistics\",\"frequency\":\"Annual\",\"source\":\"MOJ\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Performance statistics on housing and accommodation
+        outcomes for people supervised by the Probation Service.\",\"ownerEmail\":\"crosscuttingperformanceenquiries@justice.gov.uk\",\"currentPublishDate\":\"25
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-25T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"community-employment-management\",\"name\":\"Offender
+        employment outcomes\",\"indexUri\":\"https://www.gov.uk/government/collections/offender-employment-outcome-statistics\",\"frequency\":\"Annual\",\"source\":\"MOJ\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Performance statistics on employment outcomes
+        for people supervised by the Probation Service.\",\"ownerEmail\":\"crosscuttingperformanceenquiries@justice.gov.uk\",\"currentPublishDate\":\"25
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-25T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"omsq\",\"name\":\"Offender management statistics quarterly\",\"indexUri\":\"https://www.gov.uk/government/collections/offender-management-statistics-quarterly\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Accredited
+        official statistics\",\"description\":\"Detailed quarterly statistics on offenders
+        in custody (including offence groups, sentence lengths and nationalities),
+        and quarterly statistics on prison receptions, prison releases, adjudications,
+        licence recalls and offenders\u2026\",\"ownerEmail\":\"OMSQ-SiC-publications@justice.gov.uk\",\"currentPublishDate\":\"25
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-25T00:00:00+00:00\",\"nextPublishDate\":\"31
+        October 2024 9:30am\",\"nextPublishDateAsDateTime\":\"2024-10-31T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"prison-performance\",\"name\":\"Prison performance
+        ratings\",\"indexUri\":\"https://www.gov.uk/government/collections/prison-and-probation-trusts-performance-statistics#prison-performance-statistics\",\"frequency\":\"Annual\",\"source\":\"MOJ\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Annual performance ratings of prison establishments
+        in England and Wales.\\r\\n\",\"ownerEmail\":\"SUEPer_Stats@justice.gov.uk\",\"currentPublishDate\":\"25
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-25T00:00:00+00:00\",\"nextPublishDate\":\"31
+        July 2025 9:30am\",\"nextPublishDateAsDateTime\":\"2025-07-31T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"prison-population\",\"name\":\"Prison population statistics\",\"indexUri\":\"https://www.gov.uk/government/collections/prison-population-statistics\",\"frequency\":\"Annual\",\"source\":\"MOJ\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Statistics on the prison population.\",\"ownerEmail\":null,\"currentPublishDate\":\"25
+        July 2024\",\"currentPublishDateAsDate\":\"2024-07-25T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"prison-types\",\"name\":\"Prisons and their resettlement
+        providers\",\"indexUri\":\"https://www.gov.uk/government/publications/prisons-and-their-resettlement-providers\",\"frequency\":\"AdHoc\",\"source\":\"MOJ\",\"documentType\":null,\"description\":null,\"ownerEmail\":null,\"currentPublishDate\":\"24
+        January 2024\",\"currentPublishDateAsDate\":\"2024-01-24T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"proven-reoffending\",\"name\":\"Proven reoffending
+        statistics\",\"indexUri\":\"https://www.gov.uk/government/collections/proven-reoffending-statistics\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Accredited
+        official statistics\",\"description\":\"Statistics on reoffending of offenders
+        who were released from custody, received a non-custodial conviction, or a
+        caution.\",\"ownerEmail\":\"reoffendingstatistics@justice.gov.uk\",\"currentPublishDate\":\"31
+        October 2024\",\"currentPublishDateAsDate\":\"2024-10-31T00:00:00+00:00\",\"nextPublishDate\":\"30
+        January 2025 9:30am\",\"nextPublishDateAsDateTime\":\"2025-01-30T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"substance-misuse-treatment-successfully-engage\",\"name\":\"Public
+        Health Outcomes Framework\",\"indexUri\":\"https://fingertips.phe.org.uk/profile/public-health-outcomes-framework/data#page/4/gid/1000042/ati/15/iid/92544/age/168/sex/4/cat/-1/ctp/-1/yrr/1/cid/4/tbm/1/page-options/ovw-do-1_car-ao-1_car-do-1_tre-ao-0_tre-do-0\",\"frequency\":\"AdHoc\",\"source\":\"OHID\",\"documentType\":\"Official
+        Statistics\",\"description\":\"The Public Health Outcomes Framework (PHOF)
+        examines indicators that help us understand trends in public health. The data
+        are presented in an interactive tool that allows users to view them in a user-friendly
+        format. The dat\u2026\",\"ownerEmail\":null,\"currentPublishDate\":\"6 August
+        2024\",\"currentPublishDateAsDate\":null,\"nextPublishDate\":\"5 November
+        2024 9:30am\",\"nextPublishDateAsDateTime\":\"2024-11-05T09:30:00Z\",\"sourceName\":\"Office
+        for Health Improvement and Disparities\"},{\"id\":\"safety-in-custody\",\"name\":\"Safety
+        in custody statistics\",\"indexUri\":\"https://www.gov.uk/government/collections/safety-in-custody-statistics\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Accredited
+        official statistics\",\"description\":\"Quarterly update on deaths, self-harm
+        and assaults in prison custody in England and Wales. Annual detailed data
+        on assaults and self-harm in prison custody.\",\"ownerEmail\":\"OMSQ-SiC-publications@justice.gov.uk\",\"currentPublishDate\":\"31
+        October 2024\",\"currentPublishDateAsDate\":\"2024-10-31T00:00:00+00:00\",\"nextPublishDate\":\"30
+        January 2025 9:30am\",\"nextPublishDateAsDateTime\":\"2025-01-30T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"},{\"id\":\"alcohol-drug-treatment-statistics\",\"name\":\"Substance
+        misuse treatment in secure settings\",\"indexUri\":\"https://www.gov.uk/government/collections/alcohol-and-drug-misuse-and-treatment-statistics#alcohol-and-drug-treatment-statistics:-prisons-and-secure-settings\",\"frequency\":\"Annual\",\"source\":\"OHID\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Healthcare professionals can use these resources
+        to understand outcomes of alcohol and drug treatment services in secure settings
+        in England, the profile of adults and young people accessing alcohol and drug
+        treatment service\u2026\",\"ownerEmail\":\"evidenceapplicationteam@dhsc.gov.uk\",\"currentPublishDate\":\"25
+        January 2024\",\"currentPublishDateAsDate\":\"2024-01-25T00:00:00+00:00\",\"nextPublishDate\":\"30
+        January 2025 9:30am\",\"nextPublishDateAsDateTime\":\"2025-01-30T09:30:00Z\",\"sourceName\":\"Office
+        for Health Improvement and Disparities\"},{\"id\":\"cost-of-crime\",\"name\":\"The
+        economic and social costs of crime\",\"indexUri\":\"https://www.gov.uk/government/publications/the-economic-and-social-costs-of-crime\",\"frequency\":\"AdHoc\",\"source\":\"HO\",\"documentType\":null,\"description\":null,\"ownerEmail\":\"crimeandpolicestats@homeoffice.gov.uk\",\"currentPublishDate\":\"23
+        July 2018\",\"currentPublishDateAsDate\":\"2018-07-23T00:00:00+00:00\",\"nextPublishDate\":null,\"nextPublishDateAsDateTime\":null,\"sourceName\":\"Home
+        Office\"},{\"id\":\"courts-tribunals\",\"name\":\"Tribunals statistics quarterly\",\"indexUri\":\"https://www.gov.uk/government/collections/tribunals-statistics\",\"frequency\":\"Quarterly\",\"source\":\"MOJ\",\"documentType\":\"Official
+        Statistics\",\"description\":\"Type and volume of tribunal cases received,
+        disposed of or outstanding. This also includes statistics on the Gender Recognition
+        Certificate applied for and granted by HMCTS Gender Recognition Panel.\",\"ownerEmail\":\"CAJS@justice.gov.uk\",\"currentPublishDate\":\"3
+        October 2024\",\"currentPublishDateAsDate\":null,\"nextPublishDate\":\"12
+        December 2024 9:30am\",\"nextPublishDateAsDateTime\":\"2024-12-12T09:30:00Z\",\"sourceName\":\"Ministry
+        of Justice\"}]"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 13 Nov 2024 15:24:01 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_justice_data_source.py
+++ b/tests/test_justice_data_source.py
@@ -75,6 +75,12 @@ def test_chart(mock_justice_data_api, default_owner_email):
     )
     assert first_chart_domain.aspect.domains[0] == "urn:li:domain:General"
 
+    assert chartinfo.customProperties == {
+        "audience": "Published",
+        "dc_access_requirements": "",
+        "refresh_frequency": "Quarterly",
+    }
+
 
 def test_corp_group(mock_justice_data_api, default_owner_email):
     corp_group = next(


### PR DESCRIPTION
## New properties
This adds the `audience` custom property and ensures the `lastModified` date is set correctly in Datahub, as this is what we should be using for data last updated. `lastRefreshed` is set to the same value - as far as I'm aware in Justice Data there is no distinction between metadata last updated and data last updated - it's all tied to the publication dates.

`refresh_frequency` was already there but I added an extra check to make sure it is one of the expected values.

For now I've left out the property for provider/source - we're not sure what we want to do with this yet. Every Justice Data chart is already associated with a platform of Justice Data and belongs to a dashboard called Justice Data so I didn't want to add additional redundant fields.

## Refactor
As part of this PR I've also moved a bit of formatting code from `api_client` to `source` to separate the concerns of parsing Justice Data's API response vs constructing the metadata change proposal for Datahub.