### PR TITLE
Fmd 1043 cadet run results

### DIFF
--- a/.github/workflows/ingest-cadet-metadata.yml
+++ b/.github/workflows/ingest-cadet-metadata.yml
@@ -72,6 +72,9 @@ jobs:
           DATAHUB_GMS_URL: ${{ vars.DATAHUB_GMS_URL }}
           DATAHUB_TELEMETRY_ENABLED: false
         run: time poetry run datahub ingest -c ingestion/create_cadet_databases.yaml
+      
+      - name: run cadet_run_results.py
+        run: poetry run python ingestion/cadet_run_results.py
 
       - name: push metadata to datahub
         id: push_datahub

--- a/ingestion/cadet_run_results.py
+++ b/ingestion/cadet_run_results.py
@@ -43,4 +43,4 @@ def get_cadet_run_result_paths(bucket_name="mojap-derived-tables", days=1):
 
 
 if __name__ == "__main__":
-    inject_run_result_paths_into_yaml_template("ingestion/cadet.yml")
+    inject_run_result_paths_into_yaml_template("ingestion/cadet.yaml")

--- a/ingestion/cadet_run_results.py
+++ b/ingestion/cadet_run_results.py
@@ -11,7 +11,8 @@ def inject_run_result_paths_into_yaml_template(yaml_path):
 
     template["source"]["config"]["run_results_paths"] = get_cadet_run_result_paths()
 
-    with open("ingestion/cadet_with_run_results.yml", "w") as f:
+    # Overwite the original file with updated the run results paths.
+    with open(yaml_path, "w") as f:
         yaml.dump(template, f, indent=2, sort_keys=False, default_flow_style=False)
 
 

--- a/ingestion/cadet_run_results.py
+++ b/ingestion/cadet_run_results.py
@@ -1,0 +1,45 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import yaml
+
+
+def inject_run_result_paths_into_yaml_template(yaml_path):
+    with open(yaml_path) as f:
+        template = yaml.safe_load(f)
+
+    template["source"]["config"]["run_results_paths"] = get_cadet_run_result_paths()
+
+    with open("ingestion/cadet_with_run_results.yml", "w") as f:
+        yaml.dump(template, f, indent=2, sort_keys=False, default_flow_style=False)
+
+
+def get_cadet_run_result_paths(bucket_name="mojap-derived-tables", days=1):
+    """
+    Find all keys in an S3 bucket that have a 'run_results.json' file.
+    for last given amount of days
+    """
+    s3_client = boto3.client("s3")
+    keys_with_run_results = []
+    date_to_return = datetime.now(timezone.utc) - timedelta(days=days)
+    paginator = s3_client.get_paginator("list_objects_v2")
+    response_iterator = paginator.paginate(
+        Bucket=bucket_name, Prefix="prod/run_artefacts/"
+    )
+
+    for page in response_iterator:
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                key = obj["Key"]
+                last_modified = obj["LastModified"]
+                if key.endswith("run_results.json") and last_modified >= date_to_return:
+                    keys_with_run_results.append(
+                        os.path.join("s3://", bucket_name, key)
+                    )
+
+    return keys_with_run_results
+
+
+if __name__ == "__main__":
+    inject_run_result_paths_into_yaml_template("ingestion/cadet.yml")

--- a/tests/test_get_run_results_paths.py
+++ b/tests/test_get_run_results_paths.py
@@ -1,16 +1,64 @@
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+import os
+from unittest.mock import patch, mock_open
+import yaml
 
 from ingestion.cadet_run_results import (
     get_cadet_run_result_paths,
     inject_run_result_paths_into_yaml_template,
 )
 
+yaml_data = {
+    "source": {
+        "type": "dbt",
+        "config": {
+            "aws_connection": {"aws_region": "eu-west-1"},
+            "manifest_path": "s3://mojap-derived-tables/prod/run_artefacts/latest/target/manifest.json",
+            "catalog_path": "s3://mojap-derived-tables/prod/run_artefacts/latest/target/catalog.json",
+            "run_results_paths": [
+                "s3://mojap-derived-tables/prod/run_artefacts/latest/target/run_results.json"
+            ],
+        },
+    }
+}
 
+
+@patch("ingestion.cadet_run_results.get_cadet_run_result_paths")
 def test_inject_run_results_into_yaml_template(
-    mock_get_run_result_paths, mock_yaml_dump, mock_yaml_safe_load, mock_open
+    mock_cadet_run_result_paths,
+    cadet_test_recipe_path="tests/data/cadet_test_recipe_file.yaml",
 ):
-    pass
+    mock_cadet_run_result_paths.return_value = [
+        "s3://mojap-derived-tables/prod/run_artefacts/run_results.json",
+        "s3://mojap-derived-tables/prod/run_artefacts/123/run_results.json",
+    ]
+    with open(cadet_test_recipe_path, "w") as f:
+        yaml.dump(yaml_data, f, indent=2, sort_keys=False, default_flow_style=False)
+
+    inject_run_result_paths_into_yaml_template(cadet_test_recipe_path)
+
+    with open(cadet_test_recipe_path) as f:
+        template = yaml.safe_load(f)
+
+    assert (
+        template["source"]["config"]["aws_connection"]
+        == yaml_data["source"]["config"]["aws_connection"]
+    )
+    assert (
+        template["source"]["config"]["manifest_path"]
+        == yaml_data["source"]["config"]["manifest_path"]
+    )
+    assert (
+        template["source"]["config"]["catalog_path"]
+        == yaml_data["source"]["config"]["catalog_path"]
+    )
+
+    assert template["source"]["config"]["run_results_paths"] == [
+        "s3://mojap-derived-tables/prod/run_artefacts/run_results.json",
+        "s3://mojap-derived-tables/prod/run_artefacts/123/run_results.json",
+    ]
+
+    os.remove(cadet_test_recipe_path)
 
 
 @patch("boto3.client")

--- a/tests/test_get_run_results_paths.py
+++ b/tests/test_get_run_results_paths.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta, timezone
 import os
-from unittest.mock import patch, mock_open
+from datetime import datetime, timedelta, timezone
+from unittest.mock import mock_open, patch
+
 import yaml
 
 from ingestion.cadet_run_results import (
@@ -18,8 +19,58 @@ yaml_data = {
             "run_results_paths": [
                 "s3://mojap-derived-tables/prod/run_artefacts/latest/target/run_results.json"
             ],
+            "platform_instance": "cadet",
+            "target_platform": "athena",
+            "target_platform_instance": "athena_cadet",
+            "infer_dbt_schemas": True,
+            "write_semantics": "OVERRIDE",
+            "node_name_pattern": {
+                "deny": [
+                    ".*use_of_force\\.summary_status_complete_dim.*",
+                    ".*use_of_force\\.summary_status_in_progress_dim.*",
+                    ".*use_of_force\\.summary_status_submitted_dim.*",
+                    ".*data_eng_uploader_prod_calc_release_dates\\.survey_data.*",
+                    "source.mojap_derived_tables.oasys.*",
+                    "source.mojap_derived_tables.delius.*",
+                    ".*avature_stg\\.stg_people_fields_pivoted_wide.*",
+                    ".*avature_stg\\.stg_job_fields_pivoted_wide.*",
+                    "source.mojap_derived_tables.data_eng_uploader_prod_calc_release_dates.survey_data",
+                ]
+            },
+            "entities_enabled": {
+                "test_results": "YES",
+                "seeds": "YES",
+                "snapshots": "NO",
+                "models": "YES",
+                "sources": "YES",
+                "test_definitions": "YES",
+            },
+            "stateful_ingestion": {"enabled": True, "remove_stale_metadata": True},
+            "include_compiled_code": False,
+            "include_column_lineage": False,
+            "strip_user_ids_from_email": False,
+            "tag_prefix": "",
+            "meta_mapping": {
+                "dc_data_custodian": {
+                    "match": ".*",
+                    "operation": "add_owner",
+                    "config": {"owner_type": "user", "owner_category": "DATAOWNER"},
+                }
+            },
         },
-    }
+    },
+    "transformers": [
+        {
+            "type": "ingestion.transformers.assign_cadet_databases.AssignCadetDatabases",
+            "config": {
+                "manifest_s3_uri": "s3://mojap-derived-tables/prod/run_artefacts/latest/target/manifest.json"
+            },
+        },
+        {
+            "type": "simple_add_dataset_properties",
+            "config": {"properties": {"audience": "Internal"}},
+        },
+    ],
 }
 
 
@@ -40,23 +91,11 @@ def test_inject_run_results_into_yaml_template(
     with open(cadet_test_recipe_path) as f:
         template = yaml.safe_load(f)
 
-    assert (
-        template["source"]["config"]["aws_connection"]
-        == yaml_data["source"]["config"]["aws_connection"]
-    )
-    assert (
-        template["source"]["config"]["manifest_path"]
-        == yaml_data["source"]["config"]["manifest_path"]
-    )
-    assert (
-        template["source"]["config"]["catalog_path"]
-        == yaml_data["source"]["config"]["catalog_path"]
-    )
-
-    assert template["source"]["config"]["run_results_paths"] == [
+    yaml_data["source"]["config"]["run_results_paths"] = [
         "s3://mojap-derived-tables/prod/run_artefacts/run_results.json",
         "s3://mojap-derived-tables/prod/run_artefacts/123/run_results.json",
     ]
+    assert template == yaml_data
 
     os.remove(cadet_test_recipe_path)
 

--- a/tests/test_get_run_results_paths.py
+++ b/tests/test_get_run_results_paths.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from ingestion.cadet_run_results import (
+    get_cadet_run_result_paths,
+    inject_run_result_paths_into_yaml_template,
+)
+
+
+def test_inject_run_results_into_yaml_template(
+    mock_get_run_result_paths, mock_yaml_dump, mock_yaml_safe_load, mock_open
+):
+    pass
+
+
+@patch("boto3.client")
+@patch("ingestion.cadet_run_results.datetime")
+def test_get_run_result_paths(mock_datetime, mock_boto3_client):
+    mock_s3_client = mock_boto3_client.return_value
+    mock_paginator = mock_s3_client.get_paginator.return_value
+    mock_response_iterator = mock_paginator.paginate.return_value
+    mock_datetime.now.return_value = datetime(2023, 10, 10, tzinfo=timezone.utc)
+    mock_datetime.timedelta = timedelta
+
+    mock_response_iterator.__iter__.return_value = [
+        {
+            "Contents": [
+                {
+                    "Key": "prod/run_artefacts/run_results.json",
+                    "LastModified": datetime(2023, 10, 9, tzinfo=timezone.utc),
+                },
+                {
+                    "Key": "prod/run_artefacts/123/run_results.json",
+                    "LastModified": datetime(2023, 10, 9, tzinfo=timezone.utc),
+                },
+                {
+                    "Key": "prod/run_artefacts/123/run_results.json",
+                    "LastModified": datetime(2023, 9, 8, tzinfo=timezone.utc),
+                },
+                {
+                    "Key": "prod/run_artefacts/other_file.json",
+                    "LastModified": datetime(2023, 10, 9, tzinfo=timezone.utc),
+                },
+            ]
+        }
+    ]
+
+    result = get_cadet_run_result_paths(days=1)
+    assert result == [
+        "s3://mojap-derived-tables/prod/run_artefacts/run_results.json",
+        "s3://mojap-derived-tables/prod/run_artefacts/123/run_results.json",
+    ]


### PR DESCRIPTION
PR for https://github.com/ministryofjustice/find-moj-data/issues/1043

Addressing the issue where we were not pulling run results for every dbt model.

This adds a step to the cadet ingestion workflow prior to `push to metadata datahub` to populate the `cadet.yaml` recipe with a list containing each `run_results.json` file from s3 where previously we just used the file in `/latest`