### PR TITLE
enable stateful ingestion

### DIFF
--- a/ingestion/cadet.yaml
+++ b/ingestion/cadet.yaml
@@ -42,6 +42,7 @@ source:
       sources: "YES"
       test_definitions: "YES"
     stateful_ingestion:
+      enabled: true
       remove_stale_metadata: true
 
     # SQLglot sometimes raises RecursionError with valid SQL.


### PR DESCRIPTION
our cadet ingestion doesn't appear to be removing stale metadata. Look like we never enabled it as the default for the enabled key is `false`.