### PR TITLE
Stateful ingestion

### DIFF
--- a/ingestion/justice_data_ingest.yaml
+++ b/ingestion/justice_data_ingest.yaml
@@ -1,3 +1,4 @@
+pipeline_name: justice-data
 source:
   type: ingestion.justice_data_source.source.JusticeDataAPISource
   config:
@@ -6,3 +7,6 @@ source:
       - justice-in-numbers
     access_requirements: You are free to re-use the data internally or externally without requesting permission.
     default_owner_email: statistics.enquiries@justice.gov.uk
+    stateful_ingestion:
+      enabled: true
+      remove_stale_metadata: true

--- a/ingestion/justice_data_source/config.py
+++ b/ingestion/justice_data_source/config.py
@@ -1,4 +1,12 @@
+from typing import Optional
+
 from datahub.configuration.common import ConfigModel
+from datahub.ingestion.source.state.stale_entity_removal_handler import (
+    StatefulStaleMetadataRemovalConfig,
+)
+from datahub.ingestion.source.state.stateful_ingestion_base import (
+    StatefulIngestionConfigBase,
+)
 from pydantic import Field
 
 # These map the api ids to domains as set by create_cadet_database_source.py
@@ -18,7 +26,7 @@ ID_TO_DOMAIN_MAPPING = {
 }
 
 
-class JusticeDataAPIConfig(ConfigModel):
+class JusticeDataAPIConfig(StatefulIngestionConfigBase):
     base_url: str = Field(description="URL to justice data API")
     exclude_id_list: list[str] = Field(
         description="list of ids to exclude from the ingestion, inclusive of that id and all children",
@@ -35,4 +43,11 @@ class JusticeDataAPIConfig(ConfigModel):
         description="""
             The owner email will default to this email if the `ownerEmail key is not found
             at the /publications endpoint""",
+    )
+    stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = Field(
+        description="""
+            Can configure whether the ingestion is be be staeful and can remove stale metadata.
+            see https://datahubproject.io/docs/metadata-ingestion/docs/dev_guides/stateful/#stale-entity-removal
+            """,
+        default=None,
     )


### PR DESCRIPTION
This PR enables stateful ingestion in the custom ingestion source we've written for justice-data.

This means it will soft-delete entities that are not in the data for ingestion in any latest run when compared to the previous run.

We currently delete all justice-data before each ingestion but this is a better approach.

datahub guidance: https://datahubproject.io/docs/metadata-ingestion/docs/dev_guides/add_stateful_ingestion_to_source/

I tested this by not excluding any ids and then reingesting and then adding the exclusions back in for another ingestion, this is logged by the source report (and the entities are removed from datahub)
```
[2024-11-27 15:09:24,213] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,jin-prison-population-age)
[2024-11-27 15:09:24,214] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,jin-legal-aid-total-expenditure)
[2024-11-27 15:09:24,214] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,mi015b)
[2024-11-27 15:09:24,214] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:corpGroup:crosscuttingperformanceenquiries
[2024-11-27 15:09:24,215] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,court-number-of-receipts-rape)
[2024-11-27 15:09:24,215] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,jin-prison-ownership)
[2024-11-27 15:09:24,215] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,mi014)
[2024-11-27 15:09:24,215] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,jin-prison-population-offence)
[2024-11-27 15:09:24,216] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,mi015a)
[2024-11-27 15:09:24,216] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,mi016)
[2024-11-27 15:09:24,216] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,entry-to-completion-crown-mean-all)
[2024-11-27 15:09:24,216] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,jin-prison-type)
[2024-11-27 15:09:24,216] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,mi017a)
[2024-11-27 15:09:24,217] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,mi017b)
[2024-11-27 15:09:24,217] INFO     {datahub.ingestion.source.state.stale_entity_removal_handler:216} - Soft-deleting stale entity - urn:li:chart:(justice-data,jin-prison-population-sex)
```

We should look to implement the same across our other custom ingestion sources.