### PR TITLE
Treat justice data email as a contact email

### DIFF
--- a/ingestion/justice_data_source/source.py
+++ b/ingestion/justice_data_source/source.py
@@ -38,6 +38,7 @@ from datahub.metadata.schema_classes import (
     DashboardInfoClass,
     DomainsClass,
     GlobalTagsClass,
+    OwnershipClass,
     TagAssociationClass,
 )
 from datahub.utilities.time import datetime_to_ts_millis
@@ -181,11 +182,14 @@ class JusticeDataAPISource(StatefulIngestionSourceBase):
         # add tag so entity displays in find-moj-data
         display_tag = self._make_tags_aspect()
 
+        # wipe all owners (this can be removed if/when we reintroduce owners to Justice Data charts)
+        owners = OwnershipClass(owners=[])
+
         yield from [
             mcp.as_workunit()
             for mcp in MetadataChangeProposalWrapper.construct_many(
                 entityUrn=chart_urn,
-                aspects=[chart_info, display_tag, Status(removed=False)],
+                aspects=[chart_info, display_tag, Status(removed=False), owners],
             )
         ]
 

--- a/tests/test_justice_data_source.py
+++ b/tests/test_justice_data_source.py
@@ -64,12 +64,6 @@ def test_chart(mock_justice_data_api, default_owner_email):
         == '<p class="govuk-body">Applications determination granted.</p>'
     )
 
-    chart_owner = first_chart.aspects[-1]
-    assert (
-        chart_owner.owners[0].owner
-        == f"urn:li:corpGroup:{default_owner_email.split('@')[0]}"
-    )
-
     first_chart_domain = next(
         r.metadata for r in mock_justice_data_api if hasattr(r.metadata, "aspect")
     )
@@ -79,17 +73,8 @@ def test_chart(mock_justice_data_api, default_owner_email):
         "audience": "Published",
         "dc_access_requirements": "",
         "refresh_period": "Quarterly",
+        "dc_team_email": "not.me@justice.gov.uk",
     }
-
-
-def test_corp_group(mock_justice_data_api, default_owner_email):
-    corp_group = next(
-        r.metadata.proposedSnapshot
-        for r in mock_justice_data_api
-        if "corpgroup" in r.metadata.proposedSnapshot.urn.lower()
-    )
-
-    assert corp_group.urn == f"urn:li:corpGroup:{default_owner_email.split('@')[0]}"
 
 
 def test_dashboard(mock_justice_data_api):

--- a/tests/test_justice_data_source.py
+++ b/tests/test_justice_data_source.py
@@ -44,16 +44,15 @@ def test_workunits_created(mock_justice_data_api):
 
 
 def test_chart(mock_justice_data_api, default_owner_email):
-    first_chart = next(
-        r.metadata.proposedSnapshot
-        for r in mock_justice_data_api
-        if "chart" in r.metadata.proposedSnapshot.urn
-    )
-    assert (
-        first_chart.urn
+    chart_aspects = {
+        wu.metadata.aspectName: wu.metadata.aspect
+        for wu in mock_justice_data_api
+        if wu.get_urn()
         == "urn:li:chart:(justice-data,legal-aid-ecf-applicationsgranted)"
-    )
-    chartinfo = first_chart.aspects[1]
+    }
+    assert chart_aspects
+
+    chartinfo = chart_aspects["chartInfo"]
     assert (
         chartinfo.chartUrl
         == "https://data.justice.gov.uk/legalaid/legal-aid-ecf/legal-aid-ecf-applicationsgranted"
@@ -64,10 +63,8 @@ def test_chart(mock_justice_data_api, default_owner_email):
         == '<p class="govuk-body">Applications determination granted.</p>'
     )
 
-    first_chart_domain = next(
-        r.metadata for r in mock_justice_data_api if hasattr(r.metadata, "aspect")
-    )
-    assert first_chart_domain.aspect.domains[0] == "urn:li:domain:General"
+    first_chart_domain = chart_aspects["domains"]
+    assert first_chart_domain.domains[0] == "urn:li:domain:General"
 
     assert chartinfo.customProperties == {
         "audience": "Published",


### PR DESCRIPTION
Currently we take the owner_email from Justice Data and treat it as if it was a Data Custodian. This causes Find MoJ data to display it under a heading of "Data custodian (technical contact)".
    
This doesn't make sense - typically these emails are team mailboxes and do not correspond to a named contact.
    
Instead of this, use the new `dc_team_email` property. This will cause Find MoJ data to display it under the "Ask a question" heading.

## Before
![Screenshot 2024-12-04 at 13 17 55](https://github.com/user-attachments/assets/73c42714-5113-4462-bd84-af3eceef3064)

## After
<img width="389" alt="Screenshot 2024-12-04 at 15 48 09" src="https://github.com/user-attachments/assets/a50dd0ee-3462-45a8-a262-1d39118e8ae3">
