### PR TITLE
use ingestion envs for publication ingestion worfklows

### DIFF
--- a/.github/workflows/ingest-preprod.yml
+++ b/.github/workflows/ingest-preprod.yml
@@ -41,7 +41,7 @@ jobs:
   ingest-moj-publications-preprod:
     uses: ./.github/workflows/ingest-moj-publications.yml
     with:
-      ENVIRONMENT: preprod
+      ENVIRONMENT: preprod-ingestion
     secrets:
       DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
       SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.github/workflows/ingest-prod.yml
+++ b/.github/workflows/ingest-prod.yml
@@ -40,7 +40,7 @@ jobs:
   ingest-moj-publications-prod:
     uses: ./.github/workflows/ingest-moj-publications.yml
     with:
-      ENVIRONMENT: prod
+      ENVIRONMENT: prod-ingestion
     secrets:
       DATAHUB_GMS_TOKEN: ${{ secrets.DATAHUB_GMS_TOKEN }}
       SLACK_ALERT_WEBHOOK: ${{ secrets.SLACK_ALERT_WEBHOOK }}


### PR DESCRIPTION
these were set to prod and preprod which both require approvals and we don't want that for ingestion workflows