### PR TITLE
Increase maxTermBucketSize

### DIFF
--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -405,7 +405,7 @@ global:
     ## Search related configuration
     search:
       ## Maximum terms in aggregations
-      maxTermBucketSize: 20
+      maxTermBucketSize: 100
 
       ## Configuration around exact matching for search
       exactMatch:


### PR DESCRIPTION
This setting is currently preventing us using `aggregateAcrossEntities` to fetch a full list of tags.

I'm increasing it in preparation for the migration from domains to tags for subject areas.