### PR TITLE
filter out deploy-docs workflow runs from run results

### DIFF
--- a/ingestion/cadet_run_results.py
+++ b/ingestion/cadet_run_results.py
@@ -34,7 +34,11 @@ def get_cadet_run_result_paths(bucket_name="mojap-derived-tables", days=1):
             for obj in page["Contents"]:
                 key = obj["Key"]
                 last_modified = obj["LastModified"]
-                if key.endswith("run_results.json") and last_modified >= date_to_return:
+                if (
+                    key.endswith("run_results.json")
+                    and "deploy-docs" not in key
+                    and last_modified >= date_to_return
+                ):
                     keys_with_run_results.append(
                         os.path.join("s3://", bucket_name, key)
                     )

--- a/tests/test_get_run_results_paths.py
+++ b/tests/test_get_run_results_paths.py
@@ -128,6 +128,10 @@ def test_get_run_result_paths(mock_datetime, mock_boto3_client):
                     "Key": "prod/run_artefacts/other_file.json",
                     "LastModified": datetime(2023, 10, 9, tzinfo=timezone.utc),
                 },
+                {
+                    "Key": "prod/run_artefacts/deploy-docs/run_results.json",
+                    "LastModified": datetime(2023, 11, 10, tzinfo=timezone.utc),
+                },
             ]
         }
     ]


### PR DESCRIPTION
this metadata is misinterpreted by the dbt source as it assumes timestamps relate to when models were built, but actually it's just when the docs were generated.