### PR TITLE
Fix seed tags

### DIFF
--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -268,15 +268,6 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
                         (database, table, database_metadata_dict["domain"])
                     )
 
-                    database, table = parse_database_and_table_names(
-                        manifest["nodes"][node]
-                    )
-                    database_metadata_dict["domain"] = fqn[1]
-                    database_mappings.add((database, database_metadata_tuple))
-                    table_mappings.add(
-                        (database, table, database_metadata_dict["domain"])
-                    )
-
                     tags = get_tags(manifest["nodes"][node])
                     if tags:
                         tag_mappings[database] = tags

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -225,9 +225,7 @@ ValueType = TypeVar("ValueType")
 class NodeLookup(Generic[ValueType]):
     """
     Container class for storing values associated with a node.
-    Values can be fetched by database and table.
-    If table is ommitted, return the value from the last added
-    node matching the database.
+    Values can be fetched by database and table, or iterated over.
     """
 
     def __init__(self):
@@ -235,6 +233,11 @@ class NodeLookup(Generic[ValueType]):
         self.table_lookup = {}
 
     def get(self, database: str, table: str = "") -> ValueType:
+        """
+        Get the value associated with a database/table.
+        If table is ommitted, return the value from the last added
+        node matching the database.
+        """
         if table:
             return self.table_lookup[(database, table)]
         else:

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -245,7 +245,7 @@ class NodeLookup(Generic[ValueType]):
 
     def set(self, database: str, table: str, value: ValueType):
         self.database_lookup[database] = value
-        self.table_lookup[(database, table)] = table
+        self.table_lookup[(database, table)] = value
 
     def __iter__(self):
         return (

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -85,7 +85,7 @@ class TestCreateCadetDatabases:
         user_urns = [event.metadata.entityUrn for event in user_creation_events]
         assert user_urns == ["urn:li:corpuser:some.one", "urn:li:corpuser:some.team"]
 
-    def test_seeds_are_tagged_to_display_in_catalogue(self):
+    def test_seeds_are_tagged_to_display_in_catalogue_and_subject_area(self):
         seed_tag_event = [
             result
             for result in self.results_by_aspect_type[GlobalTagsClass]
@@ -93,10 +93,11 @@ class TestCreateCadetDatabases:
         ]
         assert seed_tag_event[0].metadata.entityType == "dataset"
         assert seed_tag_event[0].metadata.changeType == "UPSERT"
-        assert (
-            seed_tag_event[0].metadata.aspect.tags[0].tag
-            == "urn:li:tag:dc_display_in_catalogue"
-        )
+        tag_names = {tag.tag for tag in seed_tag_event[0].metadata.aspect.tags}
+        assert tag_names == {
+            "urn:li:tag:dc_display_in_catalogue",
+            "urn:li:tag:Postcodes",
+        }
 
     def test_datasets_are_assigned_to_domains(self):
         # This is the first event which should associate a dataset with a domain

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -85,7 +85,7 @@ class TestCreateCadetDatabases:
         user_urns = [event.metadata.entityUrn for event in user_creation_events]
         assert user_urns == ["urn:li:corpuser:some.one", "urn:li:corpuser:some.team"]
 
-    def test_seeds_are_tagged_to_display_in_catalogue_and_subject_area(self):
+    def test_seeds_are_tagged_to_display_in_catalogue(self):
         seed_tag_event = [
             result
             for result in self.results_by_aspect_type[GlobalTagsClass]
@@ -94,10 +94,7 @@ class TestCreateCadetDatabases:
         assert seed_tag_event[0].metadata.entityType == "dataset"
         assert seed_tag_event[0].metadata.changeType == "UPSERT"
         tag_names = {tag.tag for tag in seed_tag_event[0].metadata.aspect.tags}
-        assert tag_names == {
-            "urn:li:tag:dc_display_in_catalogue",
-            "urn:li:tag:Postcodes",
-        }
+        assert "urn:li:tag:dc_display_in_catalogue" in tag_names
 
     def test_datasets_are_assigned_to_domains(self):
         # This is the first event which should associate a dataset with a domain


### PR DESCRIPTION
Subject area tags were missing from seeds.

For seeds, we set the tags as part of the CreateCadetDatabases source (now badly named), but this only included the display_in_catalogue tag.

There is some separate code in the AssignCadetDatabases transformer which also sets a tags aspect but it seems like this isn't working in the case of seeds, or it is being overwritten(???)

This might benefit from some further refactoring, but I first want to make sure everything is being correctly tagged with the subject area, to avoid blocking work in the next sprint.

Since the return value of `_get_databases_with_domains_and_display_tags` didn't lend itself to looking up values for a single node, I swapped out the `table_mappings` value for a new object with a `get` method.
