### PR TITLE
perf: reduce search bulk processor limit

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -185,6 +185,7 @@ jobs:
           --version ${CHART_VERSION} \
           --atomic --debug --timeout 10m0s \
           --values helm_deploy/values-base.yaml \
+          --values helm_deploy/${{inputs.env}}/values-base.yaml \
           --namespace ${{ secrets.kube_namespace }} \
           --set datahub-frontend.fullnameOverride=${RELEASE_NAME}-${FRONTEND_FULLNAME} \
           --set datahub-frontend.oidcAuthentication.azureTenantId=${{ vars.TENANT_ID }} \

--- a/helm_deploy/dev/values-base.yaml
+++ b/helm_deploy/dev/values-base.yaml
@@ -3,4 +3,4 @@ datahub-gms:
     # Override elasticsearch.bulkProcessor.requestsLimit
     # (default: 500)
     - name: ELASTICSEARCH_BULKPROCESSOR_REQUESTSLIMIT
-      value: 250
+      value: "250"

--- a/helm_deploy/dev/values-base.yaml
+++ b/helm_deploy/dev/values-base.yaml
@@ -1,0 +1,6 @@
+datahub-gms:
+  extraEnvs:
+    # Override elasticsearch.bulkProcessor.requestsLimit
+    # (default: 500)
+    - name: ELASTICSEARCH_BULKPROCESSOR_REQUESTSLIMIT
+      value: 250

--- a/helm_deploy/preprod/values-base.yaml
+++ b/helm_deploy/preprod/values-base.yaml
@@ -1,0 +1,2 @@
+datahub-gms:
+  extraEnvs:

--- a/helm_deploy/prod/values-base.yaml
+++ b/helm_deploy/prod/values-base.yaml
@@ -1,0 +1,2 @@
+datahub-gms:
+  extraEnvs:

--- a/helm_deploy/test/values-base.yaml
+++ b/helm_deploy/test/values-base.yaml
@@ -1,0 +1,2 @@
+datahub-gms:
+  extraEnvs:


### PR DESCRIPTION
In dev, we use the smallest instance size for OpenSearch, which results in a lot of errors during search indexing, and causes the search index to become out of date with the database, leading to inconsistencies.

Example error:

OpenSearch exception [type=circuit_breaking_exception, reason=[parent] Data too large, data for [indices:data/write/bulk[s]] would be [1052493344/1003.7mb], which is larger than the limit of [1020054732/972.7mb]...

It looks like we can either increase the heap size available to the OpenSearch JVM, or we can configure Datahub to not write so many documents at once.  This commit is an attempt to do the latter.

The setting comes from here: https://github.com/datahub-project/datahub/blob/ea4d40e5353f4061fa02c4af229fdfc5a58af9d3/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactory.java#L24

And this is how it maps to environment variables: https://docs.spring.io/spring-boot/docs/2.1.x/reference/html/boot-features-external-config.html#boot-features-external-config-relaxed-binding-from-environment-variables