### PR TITLE
fmd-778 - Add webcrawler to find broken links on local run

### DIFF
--- a/crawler/go.mod
+++ b/crawler/go.mod
@@ -1,0 +1,5 @@
+module test
+
+go 1.23
+
+require golang.org/x/net v0.34.0 // indirect

--- a/crawler/main.go
+++ b/crawler/main.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"golang.org/x/net/html"
+)
+
+type Crawler struct {
+	visited      map[string]bool
+	brokenLinks  int
+	brokenReport []string
+	mu           sync.Mutex
+}
+
+func NewCrawler() *Crawler {
+	return &Crawler{
+		visited:      make(map[string]bool),
+		brokenReport: []string{},
+	}
+}
+
+func (c *Crawler) Visit(link string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.visited[link] {
+		return false
+	}
+	c.visited[link] = true
+	return true
+}
+
+func (c *Crawler) ReportBrokenLink(link string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.brokenLinks++
+	c.brokenReport = append(c.brokenReport, link)
+}
+
+func (c *Crawler) Crawl(domain string, link string, depth int) {
+	if depth <= 0 {
+		return
+	}
+
+	if !c.Visit(link) {
+		return
+	}
+	fmt.Println("Visiting:", link)
+
+	parsedURL, err := url.Parse(link)
+	if err != nil {
+		fmt.Println("Error parsing URL:", link, err)
+		return
+	}
+
+	// Properly encode query parameters
+	parsedURL.RawQuery = parsedURL.Query().Encode()
+
+	encodedLink := parsedURL.String() // Fully encoded URL
+	fmt.Println("Encoded URL:", encodedLink)
+
+	resp, err := http.Get(encodedLink)
+
+	if err != nil {
+		fmt.Println("Error fetching link:", link, err)
+		c.ReportBrokenLink(link)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println("Non-OK HTTP status:", resp.StatusCode, "for link:", link)
+		c.ReportBrokenLink(link)
+		return
+	}
+
+	links := extractLinks(resp.Body, domain)
+	for _, l := range links {
+		c.Crawl(domain, l, depth-1)
+	}
+}
+
+func extractLinks(body io.Reader, domain string) []string {
+	links := []string{}
+	page := html.NewTokenizer(body)
+
+	for {
+		tokenType := page.Next()
+		if tokenType == html.ErrorToken {
+			break
+		}
+
+		token := page.Token()
+		if tokenType == html.StartTagToken && token.Data == "a" {
+			for _, attr := range token.Attr {
+				if attr.Key == "href" {
+					link := resolveLink(attr.Val, domain)
+					if link != "" {
+						links = append(links, link)
+					}
+				}
+			}
+		}
+	}
+
+	return links
+}
+
+func resolveLink(href, domain string) string {
+	parsedLink, err := url.Parse(href)
+	if err != nil {
+		return ""
+	}
+
+	if parsedLink.Scheme == "" {
+		parsedLink.Scheme = "http"
+	}
+
+	if parsedLink.Host == "" {
+		parsedLink.Host = domain
+	}
+
+	if parsedLink.Host != domain {
+		return ""
+	}
+
+	return parsedLink.String()
+}
+
+func main() {
+	defaultURL := "http://127.0.0.1:8000"
+	defaultDepth := 5
+
+	startURL := flag.String("url", defaultURL, "Starting URL for the crawler")
+	depth := flag.Int("depth", defaultDepth, "Depth to crawl")
+	flag.Parse()
+
+	parsedURL, err := url.Parse(*startURL)
+	if err != nil {
+		fmt.Println("Invalid URL:", err)
+		return
+	}
+
+	domain := parsedURL.Host
+	crawler := NewCrawler()
+	crawler.Crawl(domain, *startURL, *depth)
+
+	fmt.Printf("Broken links encountered: %d\n", crawler.brokenLinks)
+	if crawler.brokenLinks > 0 {
+		fmt.Println("Broken links:")
+		for _, link := range crawler.brokenReport {
+			fmt.Println("-", link)
+		}
+	}
+}

--- a/crawler/main.go
+++ b/crawler/main.go
@@ -3,31 +3,35 @@ package main
 import (
 	"flag"
 	"fmt"
+	"golang.org/x/net/html"
 	"io"
 	"net/http"
 	"net/url"
-	"sync"
-
-	"golang.org/x/net/html"
+	"strings"
 )
 
 type Crawler struct {
-	visited      map[string]bool
-	brokenLinks  int
-	brokenReport []string
-	mu           sync.Mutex
+	visited          map[string]bool
+	brokenLinks      int
+	brokenReport     []string
+	brokenSources    map[string]string
+	secondaryDomains map[string]bool
 }
 
 func NewCrawler() *Crawler {
 	return &Crawler{
-		visited:      make(map[string]bool),
-		brokenReport: []string{},
+		visited:       make(map[string]bool),
+		brokenReport:  []string{},
+		brokenSources: map[string]string{},
+		secondaryDomains: map[string]bool{
+			"data.justice.gov.uk": true,
+			"www.gov.uk":          true,
+			"criminal-justice-delivery-data-dashboards.justice.gov.uk": true,
+		},
 	}
 }
 
 func (c *Crawler) Visit(link string) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.visited[link] {
 		return false
 	}
@@ -35,22 +39,25 @@ func (c *Crawler) Visit(link string) bool {
 	return true
 }
 
-func (c *Crawler) ReportBrokenLink(link string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+func (c *Crawler) ReportBrokenLink(link string, source string) {
 	c.brokenLinks++
 	c.brokenReport = append(c.brokenReport, link)
+	c.brokenSources[link] = source
+
 }
 
-func (c *Crawler) Crawl(domain string, link string, depth int) {
+func (c *Crawler) Crawl(domain string, link string, source string, depth int) {
 	if depth <= 0 {
+		return
+	}
+
+	if strings.HasPrefix(link, "http://127.0.0.1:8000/feedback/") {
 		return
 	}
 
 	if !c.Visit(link) {
 		return
 	}
-	fmt.Println("Visiting:", link)
 
 	parsedURL, err := url.Parse(link)
 	if err != nil {
@@ -58,35 +65,45 @@ func (c *Crawler) Crawl(domain string, link string, depth int) {
 		return
 	}
 
+	// Skip links outside the main domain and secondary domains
+	if parsedURL.Host != domain && !c.secondaryDomains[parsedURL.Host] {
+		return
+	}
+
+	fmt.Println("Visiting:", link)
+
 	// Properly encode query parameters
 	parsedURL.RawQuery = parsedURL.Query().Encode()
 
-	encodedLink := parsedURL.String() // Fully encoded URL
-	fmt.Println("Encoded URL:", encodedLink)
-
-	resp, err := http.Get(encodedLink)
-
+	resp, err := http.Get(link)
 	if err != nil {
 		fmt.Println("Error fetching link:", link, err)
-		c.ReportBrokenLink(link)
+		c.ReportBrokenLink(link, source)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		fmt.Println("Non-OK HTTP status:", resp.StatusCode, "for link:", link)
-		c.ReportBrokenLink(link)
+		c.ReportBrokenLink(link, source)
 		return
 	}
 
+	// Stop crawling further for secondary domains
+	if c.secondaryDomains[parsedURL.Host] {
+		fmt.Println("Checked link within secondary domain:", link)
+		return
+	}
+
+	// Extract and crawl links within the main domain
 	links := extractLinks(resp.Body, domain)
 	for _, l := range links {
-		c.Crawl(domain, l, depth-1)
+		c.Crawl(domain, l, link, depth-1)
 	}
 }
 
 func extractLinks(body io.Reader, domain string) []string {
-	links := []string{}
+	var links []string
 	page := html.NewTokenizer(body)
 
 	for {
@@ -117,6 +134,11 @@ func resolveLink(href, domain string) string {
 		return ""
 	}
 
+	// Ignore non-HTTP(S) schemes like mailto:
+	if parsedLink.Scheme != "" && parsedLink.Scheme != "http" && parsedLink.Scheme != "https" {
+		return ""
+	}
+
 	if parsedLink.Scheme == "" {
 		parsedLink.Scheme = "http"
 	}
@@ -125,16 +147,23 @@ func resolveLink(href, domain string) string {
 		parsedLink.Host = domain
 	}
 
-	if parsedLink.Host != domain {
-		return ""
-	}
+	// Normalize URL: Remove fragments and trailing slashes
+	parsedLink.Fragment = ""
+	parsedLink.Path = normalizePath(parsedLink.Path)
 
 	return parsedLink.String()
 }
 
+func normalizePath(path string) string {
+	if len(path) > 1 && path[len(path)-1] == '/' {
+		return path[:len(path)-1]
+	}
+	return path
+}
+
 func main() {
 	defaultURL := "http://127.0.0.1:8000"
-	defaultDepth := 5
+	defaultDepth := 7
 
 	startURL := flag.String("url", defaultURL, "Starting URL for the crawler")
 	depth := flag.Int("depth", defaultDepth, "Depth to crawl")
@@ -148,13 +177,13 @@ func main() {
 
 	domain := parsedURL.Host
 	crawler := NewCrawler()
-	crawler.Crawl(domain, *startURL, *depth)
+	crawler.Crawl(domain, *startURL, *startURL, *depth)
 
 	fmt.Printf("Broken links encountered: %d\n", crawler.brokenLinks)
 	if crawler.brokenLinks > 0 {
-		fmt.Println("Broken links:")
-		for _, link := range crawler.brokenReport {
-			fmt.Println("-", link)
+		fmt.Println("Broken links and their sources:")
+		for link, source := range crawler.brokenSources {
+			fmt.Printf("- %s (found on: %s)\n", link, source)
 		}
 	}
 }

--- a/crawler/readme.md
+++ b/crawler/readme.md
@@ -1,0 +1,91 @@
+# Web Crawler in Go
+
+This Go program implements a simple web crawler that traverses links on a given domain up to a specified depth. It tracks visited links, identifies broken links, and provides a report of broken or inaccessible links at the end of the crawl.
+
+**Note:** This program was built for a local instance of the `find-moj-data` app with disabled authentication.
+
+## Features
+
+- Crawls all links on a given domain up to a configurable depth.
+- Tracks and avoids revisiting previously visited links.
+- Detects broken links (e.g., HTTP errors, non-200 responses).
+- Reports the total number of broken links and their URLs.
+
+## Requirements
+
+- Go 1.19 or later.
+
+## Installation
+
+1. Clone the repository or copy the source code into a file named `webcrawler.go`.
+2. Install the required dependencies:
+   ```bash
+   go mod tidy
+   ```
+
+## Usage
+
+Build and run the program with the following steps:
+
+### Build
+
+```bash
+go build -o webcrawler
+```
+
+### Run
+
+```bash
+./webcrawler -url=<starting_url> -depth=<crawl_depth>
+```
+
+### Example
+
+To start crawling from `http://127.0.0.1:8000` with a depth of 3:
+
+```bash
+./webcrawler -url=https://127.0.0.1:8000 -depth=3
+```
+
+### Command-Line Flags
+
+- `-url`: The starting URL for the crawler. Defaults to `https://example.com`.
+- `-depth`: The depth to crawl. Defaults to `2`.
+
+## How It Works
+
+1. **Initialization**:
+   - The crawler starts from the provided URL and crawls all links belonging to the same domain.
+
+2. **Link Extraction**:
+   - Extracts and resolves valid links from `<a>` tags in the HTML document.
+   - Filters out links that point to external domains.
+
+3. **Error Handling**:
+   - Handles HTTP errors, invalid URLs, and non-OK status codes by logging them as broken links.
+
+4. **Reporting**:
+   - After completing the crawl, the program displays the total number of broken links encountered and lists their URLs.
+
+## Example Output
+
+```plaintext
+Visiting: https://example.com
+Visiting: https://example.com/page1
+Error fetching link: https://example.com/broken-page 404 Not Found
+Visiting: https://example.com/page2
+
+Broken links encountered: 1
+Broken links:
+- https://example.com/broken-page
+```
+
+## Notes
+
+- The crawler strips spaces from URLs before making requests.
+- It only crawls links within the same domain as the starting URL.
+
+## License
+
+This project is licensed under the MIT License.
+

--- a/crawler/readme.md
+++ b/crawler/readme.md
@@ -2,7 +2,8 @@
 
 This Go program implements a simple web crawler that traverses links on a given domain up to a specified depth. It tracks visited links, identifies broken links, and provides a report of broken or inaccessible links at the end of the crawl.
 
-**Note:** This program was built for a local instance of the `find-moj-data` app with disabled authentication.
+**Note:** This program was built for a local instance of the `find-moj-data` app with disabled authentication. To disable authentication
+set the variable `AZURE_AUTH_ENABLED=false` on your local `.env` file.
 
 ## Features
 


### PR DESCRIPTION
Adds a web crawler to find broken links on f-m-d.

Works against a local instance of the app with disabled auth.


Execution output:

![Uploading image.png…]()
