### PR TITLE
add fines enforcement data from Libra Green on Black

### DIFF
--- a/.github/workflows/ingest-dev.yml
+++ b/.github/workflows/ingest-dev.yml
@@ -57,6 +57,7 @@ jobs:
       COURTS_CRIMINAL_TECHNICAL_CONTACT: ${{ secrets.COURTS_CRIMINAL_TECHNICAL_CONTACT }}
       COURTS_FAMILY_TECHNICAL_CONTACT: ${{ secrets.COURTS_FAMILY_TECHNICAL_CONTACT }}
       JUST_LINK_TECHNICAL_CONTACT: ${{ secrets.JUST_LINK_TECHNICAL_CONTACT }}
+      FINES_TECHNICAL_CONTACT: ${{ secrets.FINES_TECHNICAL_CONTACT }}
   ingest-moj-publications-dev:
     uses: ./.github/workflows/ingest-moj-publications.yml
     with:

--- a/.github/workflows/ingest-glue-data.yml
+++ b/.github/workflows/ingest-glue-data.yml
@@ -36,6 +36,8 @@ on:
         required: true
       JUST_LINK_TECHNICAL_CONTACT:
         required: true
+      FINES_TECHNICAL_CONTACT:
+        required: true
 
 jobs:
   datahub-ingest-glue-data:
@@ -85,9 +87,10 @@ jobs:
           COURTS_CRIMINAL_TECHNICAL_CONTACT: ${{ secrets.COURTS_CRIMINAL_TECHNICAL_CONTACT }}
           COURTS_FAMILY_TECHNICAL_CONTACT: ${{ secrets.COURTS_FAMILY_TECHNICAL_CONTACT }}
           JUST_LINK_TECHNICAL_CONTACT: ${{ secrets.JUST_LINK_TECHNICAL_CONTACT }}
+          FINES_TECHNICAL_CONTACT: ${{ secrets.FINES_TECHNICAL_CONTACT }}
         run: |
           mkdir -p ingestion/processed
-          for config in sop contracts courts_criminal courts_family just_link; do
+          for config in contracts courts_criminal courts_family fines just_link sop; do
             envsubst < ingestion/glue_${config}.yaml > ingestion/processed/glue_${config}.yaml
           done
 

--- a/ingestion/glue_fines.yaml
+++ b/ingestion/glue_fines.yaml
@@ -1,0 +1,26 @@
+source:
+  type: glue
+  config:
+    aws_region: "eu-west-1"
+    database_pattern:
+      allow: ["fines_enforcement_v2$", "fines_enforcement_redacted_v2$"]
+    extract_owners: False
+    extract_transforms: False
+
+transformers:
+  - type: "simple_add_dataset_tags"
+    config:
+      tag_urns:
+        - "urn:li:tag:dc_display_in_catalogue"
+        - "urn:li:tag:Courts"
+  - type: "ingestion.transformers.enrich_container_transformer.EnrichContainerTransformer"
+    config:
+      data_custodian: "${FINES_TECHNICAL_CONTACT}"
+      subject_areas:
+        - Courts
+  - type: "simple_add_dataset_ownership"
+    config:
+      semantics: OVERWRITE
+      ownership_type: "DATAOWNER"
+      owner_urns:
+        - "${FINES_TECHNICAL_CONTACT}"

--- a/ingestion/glue_fines.yaml
+++ b/ingestion/glue_fines.yaml
@@ -18,6 +18,13 @@ transformers:
       data_custodian: "${FINES_TECHNICAL_CONTACT}"
       subject_areas:
         - Courts
+      properties:
+        dc_slack_channel_name: "#criminal-courts-databases"
+        dc_slack_channel_url: https://moj.enterprise.slack.com/archives/CH935DZGS
+        dc_where_to_access_dataset: AnalyticalPlatform
+        dc_access_requirements: https://user-guidance.analytical-platform.service.justice.gov.uk/tools/create-a-derived-table/database-access/#database-access
+        refresh_period: Monthly
+        audience: Internal
   - type: "simple_add_dataset_ownership"
     config:
       semantics: OVERWRITE

--- a/ingestion/glue_fines.yaml
+++ b/ingestion/glue_fines.yaml
@@ -24,3 +24,13 @@ transformers:
       ownership_type: "DATAOWNER"
       owner_urns:
         - "${FINES_TECHNICAL_CONTACT}"
+  - type: "simple_add_dataset_properties"
+    config:
+      semantics: OVERWRITE # OVERWRITE is default behaviour
+      properties:
+        dc_slack_channel_name: "#criminal-courts-databases"
+        dc_slack_channel_url: https://moj.enterprise.slack.com/archives/CH935DZGS
+        dc_where_to_access_dataset: AnalyticalPlatform
+        dc_access_requirements: https://user-guidance.analytical-platform.service.justice.gov.uk/tools/create-a-derived-table/database-access/#database-access
+        refresh_period: Monthly
+        audience: Internal


### PR DESCRIPTION
Libra Green on Black data in DEDSAI is the dataset for criminal fines enforcement (so owned by HMCTS), so cases that appear in the mags/crown court data where the defendant is sentenced will get transferred to Libra GoB. Documentation: https://data-discovery-tool.analytical-platform.service.justice.gov.uk/fines_enforcement/index.html

Ticket: https://github.com/ministryofjustice/find-moj-data/issues/1225
Example on dev: https://dev.find-moj-data.service.justice.gov.uk/details/database/urn:li:container:c387ead97c13a9795949ff56aff30fa4