### PR TITLE
Add YAML loading for top-level subject areas and enhance tag validation

### DIFF
--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -290,8 +290,9 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
 
                     database_metadata_dict["domain"] = fqn[1]
                     database_tags = database_metadata_dict.get("tags", [])
-                    # Tags are a list which is unhashable for the tuple so it needs to be removed
+                    # A copy is needed to avoid changing the original dict, whish is reused
                     database_metadata_dict_copy = database_metadata_dict.copy()
+                    # Tags are a list which is unhashable for the tuple so it needs to be removed
                     if "tags" in database_metadata_dict_copy:
                         database_metadata_dict_copy.pop("tags")
                     database_metadata_tuple = tuple(database_metadata_dict_copy.items())

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -291,6 +291,7 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
                     database_metadata_dict["domain"] = fqn[1]
                     # Tags are a list which is unhashable for the tuple so it needs to be removed
                     database_tags = database_metadata_dict.pop("tags", [])
+                    logging.warning(f"Tags for {database} are {database_tags}")
                     database_metadata_tuple = tuple(database_metadata_dict.items())
                     database_mappings.add((database, database_metadata_tuple))
                     domain_lookup.set(database, table, database_metadata_dict["domain"])

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -293,7 +293,8 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
                     logging.warning(f"Tags for {database} are {database_tags}")
                     # Tags are a list which is unhashable for the tuple so it needs to be removed
                     database_metadata_dict_copy = database_metadata_dict.copy()
-                    database_metadata_dict_copy.pop("tags")
+                    if "tags" in database_metadata_dict_copy:
+                        database_metadata_dict_copy.pop("tags")
                     database_metadata_tuple = tuple(database_metadata_dict_copy.items())
                     database_mappings.add((database, database_metadata_tuple))
                     domain_lookup.set(database, table, database_metadata_dict["domain"])

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -288,7 +288,7 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
                         logging.debug(f"{database} - has no database level metadata")
 
                     database_metadata_dict["domain"] = fqn[1]
-                    # Tags are a list which is unhashable for the tuple
+                    # Tags are a list which is unhashable for the tuple so it needs to be removed
                     database_tags = database_metadata_dict.pop("tags", [])
                     database_metadata_tuple = tuple(database_metadata_dict.items())
                     database_mappings.add((database, database_metadata_tuple))
@@ -296,7 +296,7 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
 
                     tags = get_tags(manifest["nodes"][node])
                     if database_tags:
-                        tags.extend(database_metadata_dict.get("tags", []))
+                        tags.extend(database_tags)
                     if not any(tag in top_level_subject_areas for tag in tags):
                         logging.warning(f"No top level tags found in database metadata file for {database}")
 

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -292,8 +292,9 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
                     database_tags = database_metadata_dict.get("tags", [])
                     logging.warning(f"Tags for {database} are {database_tags}")
                     # Tags are a list which is unhashable for the tuple so it needs to be removed
-                    database_metadata_without_tags = database_metadata_dict.copy().pop("tags")
-                    database_metadata_tuple = tuple(database_metadata_without_tags.items())
+                    database_metadata_dict_copy = database_metadata_dict.copy()
+                    database_metadata_dict_copy.pop("tags")
+                    database_metadata_tuple = tuple(database_metadata_dict_copy.items())
                     database_mappings.add((database, database_metadata_tuple))
                     domain_lookup.set(database, table, database_metadata_dict["domain"])
 

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -96,7 +96,6 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
                 manifest, databases_metadata
             )
         )
-        logging.warning(f"{databases_metadata}")
 
         # create mcps for database owner corpusers
         mcps.extend(self.create_database_owner_mcps(databases_with_metadata))
@@ -290,10 +289,11 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
                         logging.debug(f"{database} - has no database level metadata")
 
                     database_metadata_dict["domain"] = fqn[1]
-                    # Tags are a list which is unhashable for the tuple so it needs to be removed
-                    database_tags = database_metadata_dict.pop("tags", [])
+                    database_tags = database_metadata_dict.get("tags", [])
                     logging.warning(f"Tags for {database} are {database_tags}")
-                    database_metadata_tuple = tuple(database_metadata_dict.items())
+                    # Tags are a list which is unhashable for the tuple so it needs to be removed
+                    database_metadata_without_tags = database_metadata_dict.copy().pop("tags")
+                    database_metadata_tuple = tuple(database_metadata_without_tags.items())
                     database_mappings.add((database, database_metadata_tuple))
                     domain_lookup.set(database, table, database_metadata_dict["domain"])
 

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -96,6 +96,7 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
                 manifest, databases_metadata
             )
         )
+        logging.warning(f"{databases_metadata}")
 
         # create mcps for database owner corpusers
         mcps.extend(self.create_database_owner_mcps(databases_with_metadata))

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -166,7 +166,7 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
             else:
                 database_description = None
 
-            logging.info(f"Creating container {database_name=} with {domain_name=}")
+            logging.info(f"Creating container {database_name=} with {domain_name=} with {tags=}")
             yield from mcp_builder.gen_containers(
                 container_key=database_container_key,
                 name=database_name,

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -288,12 +288,15 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
                         logging.debug(f"{database} - has no database level metadata")
 
                     database_metadata_dict["domain"] = fqn[1]
+                    # Tags are a list which is unhashable for the tuple
+                    database_tags = database_metadata_dict.pop("tags", [])
                     database_metadata_tuple = tuple(database_metadata_dict.items())
                     database_mappings.add((database, database_metadata_tuple))
                     domain_lookup.set(database, table, database_metadata_dict["domain"])
 
                     tags = get_tags(manifest["nodes"][node])
-                    tags.extend(database_metadata_dict.get("tags", []))
+                    if database_tags:
+                        tags.extend(database_metadata_dict.get("tags", []))
                     if not any(tag in top_level_subject_areas for tag in tags):
                         logging.warning(f"No top level tags found in database metadata file for {database}")
 

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -52,7 +52,8 @@ subject_areas_filepath = os.path.join(
     os.path.dirname(__file__), "..", "tags", "subject_areas_template.yaml"
 )
 with open(subject_areas_filepath, "r") as file:
-    top_level_subject_areas = yaml.safe_load(file)
+    subject_areas_yaml = yaml.safe_load(file)
+    top_level_subject_areas = [item["name"] for item in subject_areas_yaml]
 
 
 @config_class(CreateCadetDatabasesConfig)
@@ -166,7 +167,7 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
             else:
                 database_description = None
 
-            logging.info(f"Creating container {database_name=} with {domain_name=} with {tags=}")
+            logging.info(f"Creating container {database_name=} with {domain_name=}")
             yield from mcp_builder.gen_containers(
                 container_key=database_container_key,
                 name=database_name,

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -290,7 +290,6 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
 
                     database_metadata_dict["domain"] = fqn[1]
                     database_tags = database_metadata_dict.get("tags", [])
-                    logging.warning(f"Tags for {database} are {database_tags}")
                     # Tags are a list which is unhashable for the tuple so it needs to be removed
                     database_metadata_dict_copy = database_metadata_dict.copy()
                     if "tags" in database_metadata_dict_copy:

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -16,6 +16,7 @@ from datahub.metadata.schema_classes import (
     CorpUserInfoClass,
     DomainPropertiesClass,
 )
+import yaml
 
 from ingestion.config import ENV, INSTANCE, PLATFORM
 from ingestion.utils import report_time
@@ -272,3 +273,17 @@ class NodeLookup(Generic[ValueType]):
             (database, table, domain)
             for ((database, table), domain) in self.table_lookup.items()
         )
+
+
+def get_subject_areas():
+    """
+    Returns a list of subject areas from the subject_areas_template.yaml file
+    """
+    subject_areas_filepath = os.path.join(
+        os.path.dirname(__file__), "tags", "subject_areas_template.yaml"
+    )
+    with open(subject_areas_filepath, "r") as file:
+        subject_areas_yaml = yaml.safe_load(file)
+        top_level_subject_areas = [item["name"] for item in subject_areas_yaml]
+
+    return top_level_subject_areas


### PR DESCRIPTION
EM datasets are not arranged by domain in their filesystem, so I have added tags to them in the database metadata file https://github.com/moj-analytical-services/create-a-derived-table/pull/2778

This PR adds those tags to the databases as they are created in the ingestions - this should result in the proper subject areas being shown for EM databases.

https://github.com/ministryofjustice/find-moj-data/issues/1314