### PR TITLE
Remove domain code

### DIFF
--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -29,7 +29,7 @@ This custom code is required because the dbt manifest file, used to ingest the m
 
 In the simplest terms this ingestion infers parent databases for the entities within the manifest and creates the container entities of subtype databases within datahub.
 
-It also assigns all cadet tables to domains in datahub.
+It also tags all cadet tables with subject areas in datahub.
 
 The recipe file for this component can be found [here](create_cadet_databases.yaml)
 
@@ -69,7 +69,7 @@ For these data we use Datahub's native [Glue ingestion source](https://datahubpr
 
 ### Glue databases and tables
 
-We define a recipe file for glue databases in an area, they'll be prefixed `glue_`, eg. [glue_sop.yaml](glue_sop.yaml). The recipe may contain several databases but they will have common metadata properties set, such as data custodian and domain.
+We define a recipe file for glue databases in an area, they'll be prefixed `glue_`, eg. [glue_sop.yaml](glue_sop.yaml). The recipe may contain several databases but they will have common metadata properties set, such as data custodian and subject area.
 
 ### Glue transformers
 
@@ -77,9 +77,8 @@ We have defined a transformer to add some additional metadata properties to the 
 
 Transformers used are:
 
-- [enrich_container_transformer](transformers/enrich_container_transformer.py) - Custom transformer. Adds an owner, domain, and tag for a provided container.
+- [enrich_container_transformer](transformers/enrich_container_transformer.py) - Custom transformer. Adds an owner and tags for a provided container.
 - simple_add_dataset_tags - Datahub provided transformer. Adds the `dc_display_in_catalogue` tag to all ingested entities.
-- simple_add_dataset_domain - Datahub provided transformer. Adds the given domain to all ingested entities.
 - simple_add_dataset_ownership - Datahub provided transformer. Adds the given owner to all ingested entities.
 
 ### Glue ingestion workflow
@@ -112,7 +111,7 @@ We have developed a [custom ingestion source for GOV.UK publications](moj_statis
 
 It loads all entities into a custom platform called `GOV.UK`
 
-This ingestion also has a mapping yaml file which maps publication collections to domains and team contact emails. Publication datasets inherit the domain and contact details from their parent collection.
+This ingestion also has a mapping yaml file which maps publication collections to subject areas and team contact emails. Publication datasets inherit the subject areas and contact details from their parent collection.
 
 [see the recipe](ingestion/moj_publications.yaml) for this ingestion.
 
@@ -129,7 +128,7 @@ We have developed some checks to run post ingestion to monitor whether there hav
 The initial development essentially checks three things:
 
 1. Whether any create a derived table datasets are missing an `IsPartOf` container relationship
-2. Whether any owner, domain, or tag values are in prod but not preprod or in preprod but not prod (grouped by platform)
-3. Whether the count of any entity type, owner, domain, or tag has a difference >20% comparing prod and preprod (grouped by platform)
+2. Whether any owner or tag values are in prod but not preprod or in preprod but not prod (grouped by platform)
+3. Whether the count of any entity type, owner or tag has a difference >20% comparing prod and preprod (grouped by platform)
 
 These checks are run using the github actions workflow [post-ingestion-checks.yml](../.github/workflows/post-ingestion-checks.yml), with the code for the checks in [post_ingestion_checks.py](post_ingestion_checks.py).

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -17,12 +17,7 @@ from datahub.ingestion.source.state.stale_entity_removal_handler import (
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionSourceBase,
 )
-from datahub.metadata.schema_classes import (
-    ChangeTypeClass,
-    DomainsClass,
-    GlobalTagsClass,
-    TagAssociationClass,
-)
+from datahub.metadata.schema_classes import GlobalTagsClass, TagAssociationClass
 
 from ingestion.config import ENV, INSTANCE, PLATFORM
 from ingestion.create_cadet_databases_source.config import CreateCadetDatabasesConfig

--- a/ingestion/create_cadet_databases_source/source.py
+++ b/ingestion/create_cadet_databases_source/source.py
@@ -24,7 +24,6 @@ from ingestion.create_cadet_databases_source.config import CreateCadetDatabasesC
 from ingestion.ingestion_utils import (
     NodeLookup,
     domains_to_subject_areas,
-    format_domain_name,
     get_cadet_metadata_json,
     get_subject_areas,
     get_tags,
@@ -121,9 +120,8 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
             )
             db_meta_dict = dict(database_metadata)
             db_meta_dict.update(properties_to_add)
-            domain_name = format_domain_name(db_meta_dict["domain"])
+            domain_name = db_meta_dict["domain"]
             tags = display_tags.get(database_name, ["dc_cadet"])
-            tags.append(domain_name)
             if domains_to_subject_areas.get(domain_name.lower()):
                 tags.append(domains_to_subject_areas[domain_name.lower()])
 
@@ -166,9 +164,8 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
         ]
         for node in seed_nodes:
             database, table = parse_database_and_table_names(node)
-            domain = format_domain_name(domain_lookup.get(database, table))
+            domain = domain_lookup.get(database, table)
             tag_names = [
-                domain,
                 "Reference data",
                 "dc_display_in_catalogue",
             ]
@@ -194,16 +191,6 @@ class CreateCadetDatabases(StatefulIngestionSourceBase):
 
             seed_domain_mcps.append(mcp)
         return seed_domain_mcps
-
-    def _get_domains(self, manifest) -> set[str]:
-        """Only models are arranged by domain in CaDeT.
-        Seeds should only be associated with a domain if it appears in models.
-        """
-        return set(
-            format_domain_name(manifest["nodes"][node]["fqn"][1])
-            for node in manifest["nodes"]
-            if manifest["nodes"][node]["resource_type"] == "model"
-        )
 
     @report_time
     def _get_databases_with_domains_and_display_tags(

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -3,10 +3,9 @@ import logging
 import os
 import re
 from enum import StrEnum
-from typing import Dict, Generic, Tuple, TypeVar
+from typing import Dict, Generic, TypeVar
 
 import boto3
-import datahub.emitter.mce_builder as builder
 import datahub.emitter.mce_builder as mce_builder
 import yaml
 from botocore.exceptions import ClientError, NoCredentialsError

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -12,11 +12,7 @@ import yaml
 from botocore.exceptions import ClientError, NoCredentialsError
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
-from datahub.metadata.schema_classes import (
-    ChangeTypeClass,
-    CorpUserInfoClass,
-    DomainPropertiesClass,
-)
+from datahub.metadata.schema_classes import ChangeTypeClass, CorpUserInfoClass
 
 from ingestion.config import ENV, INSTANCE, PLATFORM
 from ingestion.utils import report_time
@@ -104,26 +100,6 @@ def validate_fqn(fqn: list[str]) -> bool:
     if not match:
         logging.warning(f"{table_name=} does not match database__table format")
         return False
-
-
-def convert_cadet_manifest_table_to_datahub(node_info: dict) -> Tuple[str, str]:
-    """
-    eg 'database__table' is converted to a regex string to detect it's urn
-    like 'urn:li:dataset:\\(urn:li:dataPlatform:dbt,cadet\\.awsdatacatalog\\.database\\.table,PROD\\)'
-    """
-    domain = format_domain_name(node_info.get("fqn", [])[1])
-
-    database_name, table_name = parse_database_and_table_names(node_info)
-
-    urn = builder.make_dataset_urn_with_platform_instance(
-        platform=PLATFORM,
-        platform_instance=INSTANCE,
-        env=ENV,
-        name=f"{database_name}.{table_name}",
-    )
-    escaped_urn_for_regex = re.escape(urn)
-
-    return domain, escaped_urn_for_regex
 
 
 BIG_OLD_ACRONYMS = set(("OPG", "HMPPS", "HMCTS", "LAA", "CICA", "HQ"))

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -11,10 +11,8 @@ import datahub.emitter.mce_builder as mce_builder
 import yaml
 from botocore.exceptions import ClientError, NoCredentialsError
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
 from datahub.metadata.schema_classes import ChangeTypeClass, CorpUserInfoClass
 
-from ingestion.config import ENV, INSTANCE, PLATFORM
 from ingestion.utils import report_time
 
 logging.basicConfig(level=logging.DEBUG)
@@ -100,24 +98,6 @@ def validate_fqn(fqn: list[str]) -> bool:
     if not match:
         logging.warning(f"{table_name=} does not match database__table format")
         return False
-
-
-BIG_OLD_ACRONYMS = set(("OPG", "HMPPS", "HMCTS", "LAA", "CICA", "HQ"))
-
-
-def format_domain_name(domain_name: str) -> str:
-    """
-    Format domain names from the manifest into a human readable format, e.g.
-    courts -> Courts
-    opg -> OPG
-    hmpps -> HMPPS
-    electronic_monitoring -> Electronic monitoring
-    """
-    acronym = domain_name.upper()
-    if acronym in BIG_OLD_ACRONYMS:
-        return acronym
-
-    return domain_name.capitalize().replace("_", " ")
 
 
 def parse_database_and_table_names(node: dict) -> tuple[str, str]:

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -8,6 +8,7 @@ from typing import Dict, Generic, Tuple, TypeVar
 import boto3
 import datahub.emitter.mce_builder as builder
 import datahub.emitter.mce_builder as mce_builder
+import yaml
 from botocore.exceptions import ClientError, NoCredentialsError
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
@@ -16,7 +17,6 @@ from datahub.metadata.schema_classes import (
     CorpUserInfoClass,
     DomainPropertiesClass,
 )
-import yaml
 
 from ingestion.config import ENV, INSTANCE, PLATFORM
 from ingestion.utils import report_time
@@ -226,18 +226,6 @@ def make_user_mcp(email: str) -> MetadataChangeProposalWrapper:
     )
 
     return user_mcp
-
-
-def make_domain_mcp(domain_name: str) -> MetadataChangeProposalWrapper:
-    domain_urn = mce_builder.make_domain_urn(domain=domain_name)
-    domain_properties = DomainPropertiesClass(name=domain_name)
-    mcp = MetadataChangeProposalWrapper(
-        entityType="domain",
-        changeType=ChangeTypeClass.UPSERT,
-        entityUrn=domain_urn,
-        aspect=domain_properties,
-    )
-    return mcp
 
 
 ValueType = TypeVar("ValueType")

--- a/ingestion/ingestion_utils.py
+++ b/ingestion/ingestion_utils.py
@@ -136,43 +136,6 @@ def parse_database_and_table_names(node: dict) -> tuple[str, str]:
     return node_database_name, node_table_name
 
 
-def list_datahub_domains() -> list[str]:
-    """
-    Returns a list of domains as exists in datahub
-    """
-    server_config = DatahubClientConfig(
-        server=os.environ["DATAHUB_GMS_URL"], token=os.environ["DATAHUB_GMS_TOKEN"]
-    )
-
-    graph = DataHubGraph(server_config)
-
-    list_domains_query = """
-        {listDomains(
-            input: {start: 0, count: 50}
-        ) {
-        domains{
-            urn
-            properties{
-                name
-            }
-            entities(
-            input:{query:"*",start:0,count: 0}
-            ){
-                total
-            }
-        }
-        }
-        }
-        """
-    results = graph.execute_graphql(list_domains_query)
-
-    domains_list = [
-        domain["properties"]["name"].lower()
-        for domain in results["listDomains"]["domains"]
-    ]
-    return domains_list
-
-
 def get_tags(dbt_manifest_node: dict) -> list[str]:
     """Resolve the tags to assign to nodes in datahub."""
     tags = []

--- a/ingestion/moj_statistical_publications_source/api_client.py
+++ b/ingestion/moj_statistical_publications_source/api_client.py
@@ -5,8 +5,6 @@ from typing import Any
 
 import requests
 
-from ingestion.ingestion_utils import list_datahub_domains
-
 from .config import ID_TO_DOMAIN_CONTACT_MAPPINGS, MojPublicationsAPIParams
 
 

--- a/ingestion/moj_statistical_publications_source/api_client.py
+++ b/ingestion/moj_statistical_publications_source/api_client.py
@@ -98,21 +98,3 @@ class MojPublicationsAPIClient:
                 collection["slug"], {}
             ).get("contact_email", self.default_contact_email)
         return unique_collections
-
-    def validate_domains(self) -> bool:
-        domains = [
-            val.get("domain")
-            for val in self._id_to_domain_contact_mapping.values()
-            if val is not None
-        ]
-        domains = [domain for domain in domains if domain is not None]
-        datahub_domains = list_datahub_domains()
-        for domain in set(domains):
-            if domain.lower() not in datahub_domains:
-                raise ValueError(
-                    f"""
-                    Domain - {domain}, doesn't exist in datahub.
-                    Review domain mappings in publication_collection_mappings.yaml
-                    """
-                )
-        return True

--- a/ingestion/moj_statistical_publications_source/api_client.py
+++ b/ingestion/moj_statistical_publications_source/api_client.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import requests
 
-from .config import ID_TO_DOMAIN_CONTACT_MAPPINGS, MojPublicationsAPIParams
+from .config import ID_TO_METADATA_MAPPINGS, MojPublicationsAPIParams
 
 
 class MojPublicationsAPIClient:
@@ -14,7 +14,7 @@ class MojPublicationsAPIClient:
         self.base_url = base_url
         self.params: MojPublicationsAPIParams = params
         self.default_contact_email = default_contact_email
-        self._id_to_domain_contact_mapping = ID_TO_DOMAIN_CONTACT_MAPPINGS
+        self._id_to_metadata_mapping = ID_TO_METADATA_MAPPINGS
 
     def list_all_publications_metadata(self):
         params_dict = dict(self.params)
@@ -87,12 +87,12 @@ class MojPublicationsAPIClient:
             )
             content_response = self.session.get(content_api_url).json()
             collection["description"] = content_response.get("description")
-            collection["subject_areas"] = self._id_to_domain_contact_mapping.get(
+            collection["subject_areas"] = self._id_to_metadata_mapping.get(
                 collection["slug"], {}
             ).get("subject_areas")
 
             collection["last_updated"] = content_response.get("public_updated_at")
-            collection["contact_email"] = self._id_to_domain_contact_mapping.get(
+            collection["contact_email"] = self._id_to_metadata_mapping.get(
                 collection["slug"], {}
             ).get("contact_email", self.default_contact_email)
         return unique_collections

--- a/ingestion/moj_statistical_publications_source/api_client.py
+++ b/ingestion/moj_statistical_publications_source/api_client.py
@@ -89,9 +89,6 @@ class MojPublicationsAPIClient:
             )
             content_response = self.session.get(content_api_url).json()
             collection["description"] = content_response.get("description")
-            collection["domain"] = self._id_to_domain_contact_mapping.get(
-                collection["slug"], {}
-            ).get("domain")
             collection["subject_areas"] = self._id_to_domain_contact_mapping.get(
                 collection["slug"], {}
             ).get("subject_areas")

--- a/ingestion/moj_statistical_publications_source/config.py
+++ b/ingestion/moj_statistical_publications_source/config.py
@@ -13,7 +13,7 @@ with open(
     "ingestion/moj_statistical_publications_source/publication_collection_mappings.yaml",
     "r",
 ) as f:
-    ID_TO_DOMAIN_CONTACT_MAPPINGS = yaml.safe_load(f)
+    ID_TO_METADATA_MAPPINGS = yaml.safe_load(f)
 
 
 class MojPublicationsAPIParams(BaseModel):

--- a/ingestion/moj_statistical_publications_source/publication_collection_mappings.yaml
+++ b/ingestion/moj_statistical_publications_source/publication_collection_mappings.yaml
@@ -1,76 +1,57 @@
 accredited-programmes-annual-bulletin:
   subject_areas: ["Prisons and probation"]
   contact_email: statistics@justice.gov.uk
-  domain: Interventions
 ad-hoc-justice-statistics:
   # subject_areas: doesn't fit to any, could be multiple when we implement it
   contact_email: statistics@justice.gov.uk
-  domain: General
 alcohol-and-drug-misuse-and-treatment-statistics:
   subject_areas: ["Prisons and probation"]
-  domain: Interventions
 antisocial-behaviour:
   subject_areas: ["Crime and policing"]
-  domain: General
 civil-justice-statistics:
   subject_areas: ["Courts and tribunals", "Civil courts"]
   contact_email: CAJS@justice.gov.uk
-  domain: Courts
 civil-justice-statistics-quarterly:
   subject_areas: ["Courts and tribunals", "Civil courts"]
   contact_email: CAJS@justice.gov.uk
-  domain: Courts
 compendium-of-re-offending:
   subject_areas: ["Crime and policing"]
-  domain: General
 # coroners-and-burials-statistics:
 #   subject_areas: null  # unsure where this would fit, could make General?
 #   contact_email:
 court-statistics-quarterly:
   subject_areas: ["Courts and tribunals"]
-  domain: Courts
 crime-statistics:
   subject_areas: ["Crime and policing"]
   contact_email: CrimeandPoliceStats@homeoffice.gov.uk
-  domain: General
 criminal-court-statistics:
   subject_areas: ["Courts and tribunals", "Criminal courts"]
   contact_email: criminal_court_sta@justice.gov.uk
-  domain: Courts
 criminal-justice-statistics:
   subject_areas: ["Crime and policing"]
   contact_email: CJS_Statistics@justice.gov.uk
-  domain: General
 criminal-justice-statistics-quarterly:
   subject_areas: ["Crime and policing"]
   contact_email: CJS_Statistics@justice.gov.uk
-  domain: General
 death-of-offenders-in-the-community:
   subject_areas: ["Prisons and probation"]
   contact_email: probation-statistics-enquiries@justice.gov.uk
-  domain: Probation
 electronic-monitoring-publication:
   subject_areas: ["Prisons and probation", "Electronic monitoring"]
   contact_email: ppas_statistics@justice.gov.uk
-  domain: Electronic monitoring
 family-court-statistics-quarterly:
   subject_areas: ["Courts and tribunals", "Family courts"]
   contact_email: familycourt.statistics@justice.gov.uk
-  domain: Courts
 gender-recognition-certificate-statistics:
   subject_areas: ["Courts and tribunals"]
-  domain: Courts
 government-foi-statistics:
   subject_areas: ["Corporate operations"]
   contact_email: foistatistics@cabinetoffice.gov.uk
-  domain: General
 hate-crime-statistics:
   subject_areas: ["Crime and policing"]
   contact_email: crimeandpolicestats@homeoffice.gov.uk
-  domain: General
 hm-prison-and-probation-service-covid-19-statistics-monthly:
   subject_areas: ["Prisons and probation"]
-  domain: Probation
 hmpps-annual-offender-equalities-report:
   subject_areas: ["Prisons and probation"]
   contact_email: sueper_stats@justice.gov.uk
@@ -81,33 +62,25 @@ hmpps-covid-19-management-information-weekly:
   subject_areas: ["Prisons and probation"]
 judicial-and-court-statistics:
   subject_areas: ["Courts and tribunals"]
-  domain: Courts
 judicial-diversity-statistics:
   subject_areas: ["Courts and tribunals"]
   contact_email: judicial.statistics@justice.gov.uk
-  domain: Courts
 justice-data-lab-pilot-statistics:
   # subject_areas: doesn't fit to any, could be multiple when we implement it
   contact_email: justice.datalab@justice.gov.uk
-  domain: General
 knife-possession-sentencing-quarterly:
   subject_areas: ["Courts and tribunals"]
   contact_email: MOJPNCteam@justice.gov.uk
-  domain: Courts
 legal-aid-statistics:
   subject_areas: ["Legal aid"]
   contact_email: statistics@justice.gov.uk
-  domain: General
 legal-aid-statistics-data-files:
   subject_areas: ["Legal aid"]
-  domain: General
 local-adult-reoffending:
   subject_areas: ["Crime and policing"]
-  domain: General
 mortgage-and-landlord-possession-statistics:
   subject_areas: ["Courts and tribunals"]
   contact_email: CAJS@justice.gov.uk
-  domain: Courts
 multi-agency-public-protection-arrangements-mappa-annual-reports:
   subject_areas: ["Prisons and probation"]
   contact_email: mappa@justice.gov.uk
@@ -116,60 +89,46 @@ national-offender-management-service-workforce-statistics:
   contact_email: robert.hartley@justice.gov.uk
 new-criminal-offences-statistics:
   subject_areas: ["Crime and policing"]
-  domain: General
 offender-management-statistics-quarterly:
   subject_areas: ["Prisons and probation"]
   contact_email: OMSQ-SiC-publications@justice.gov.uk
 payment-by-results-statistics:
   subject_areas: ["Prisons and probation"]
-  domain: Probation
 prison-and-probation-trusts-performance-statistics:
   subject_areas: ["Prisons and probation"]
   contact_email: SUEPer_Stats@justice.gov.uk
 prison-population-statistics:
   subject_areas: ["Prisons and probation"]
-  domain: Prison
 prisons-and-probation-statistics:
   subject_areas: ["Prisons and probation"]
 probation-service-workforce-quarterly-reports:
   subject_areas: ["Prisons and probation"]
-  domain: Probation
 proven-reoffending-statistics:
   subject_areas: ["Crime and policing"]
   contact_email: reoffendingstatistics@justice.gov.uk
 race-and-the-criminal-justice-system:
   subject_areas: ["Crime and policing"]
   contact_email: CJS_Statistics@justice.gov.uk
-  domain: General
 restricted-patients-statistics-england-and-wales:
   # subject_areas: not sure for this
   contact_email: MHCSMailbox@justice.gov.uk
-  domain: General
 safety-in-custody-statistics:
   subject_areas: ["Prisons and probation"]
   contact_email: OMSQ-SiC-publications@justice.gov.uk
-  domain: Prison
 statistics-on-privacy-injunctions:
   subject_areas: ["Courts and tribunals"]
-  domain: Courts
 statistics-on-public-disorder-of-6-9-august-2011:
   subject_areas: ["Crime and policing"]
-  domain: General
 statistics-on-the-use-of-language-services-in-courts-and-tribunals:
   subject_areas: ["Courts and tribunals"]
-  domain: Courts
 topical-criminal-justice-publications:
   subject_areas: ["Crime and policing"]
-  domain: General
 tribunals-statistics:
   subject_areas: ["Courts and tribunals"]
   contact_email: CAJS@justice.gov.uk
-  domain: Courts
 women-and-the-criminal-justice-system:
   subject_areas: ["Crime and policing"]
   contact_email: CJS_Statistics@justice.gov.uk
-  domain: General
 youth-justice-statistics:
   subject_areas: ["Crime and policing"]
   contact_email: statistics@yjb.gov.uk
-  domain: General

--- a/ingestion/moj_statistical_publications_source/source.py
+++ b/ingestion/moj_statistical_publications_source/source.py
@@ -154,10 +154,10 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
         self, all_publications_metadata: List[Dict]
     ) -> list[MetadataChangeProposalWrapper]:
         """
-        creates the aspects for dataset properties, tags, domain, and container, for
+        creates the aspects for dataset properties, tags, and container, for
         all individual publcations as a dataset and returns as a list of mcps
 
-        All publications will not have a container or domain (if not in a collection)
+        All publications will not have a container or subject area (if not in a collection)
         """
         mcps = []
         custom_properties: dict = {
@@ -178,7 +178,7 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
             )
 
             # if publication is in a collection it's special and gets some more metadata we've collected in
-            # a mapping yaml. Namely a domain and team contact email where available
+            # a mapping yaml. Namely a subject area and team contact email where available
             if publication.get("document_collections"):
 
                 # publications can belong to multiple collections - opting to keep it more simple and register
@@ -219,8 +219,7 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
                     )
                 )
 
-                # because as is there won't always be an applicable domain (subject area)
-                # even within a colleciton
+                # there won't always be an applicable subject area, even within a collection
                 tags = [TagAssociationClass(tag="urn:li:tag:dc_display_in_catalogue")]
 
                 subject_areas = self._id_to_domain_contact_mapping.get(

--- a/ingestion/moj_statistical_publications_source/source.py
+++ b/ingestion/moj_statistical_publications_source/source.py
@@ -28,7 +28,6 @@ from datahub.metadata.schema_classes import (
     ContainerClass,
     DataPlatformInstanceClass,
     DatasetPropertiesClass,
-    DomainsClass,
     GlobalTagsClass,
     SubTypesClass,
     TagAssociationClass,
@@ -134,12 +133,6 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
                 backcompat_env_as_instance=True,
             )
             tags = ["dc_display_in_catalogue"]
-            # if collection.get("domain"):
-            #     domain_name = format_domain_name(collection["domain"])
-            #     domain_urn = mce_builder.make_domain_urn(domain=domain_name)
-            #     tags.append(domain_name)
-            # else:
-            #     domain_urn = None
 
             if collection.get("subject_areas"):
                 tags.extend(collection["subject_areas"])
@@ -238,18 +231,6 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
                 if domain:
                     domain_name = format_domain_name(domain)
                     tags.append(TagAssociationClass(tag=f"urn:li:tag:{domain_name}"))
-                    domain_urn = mce_builder.make_domain_urn(domain=domain_name)
-                else:
-                    domain_urn = None
-
-                # add domain - we only add a domain for publications within a collection
-                if domain_urn:
-                    mcps.append(
-                        MetadataChangeProposalWrapper(
-                            entityUrn=dataset_urn,
-                            aspect=DomainsClass(domains=[domain_urn]),
-                        )
-                    )
 
                 subject_areas = self._id_to_domain_contact_mapping.get(
                     parent_collection_ids[0], {}

--- a/ingestion/moj_statistical_publications_source/source.py
+++ b/ingestion/moj_statistical_publications_source/source.py
@@ -54,7 +54,6 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
         self,
         ctx: PipelineContext,
         config: MojPublicationsAPIConfig,
-        validate_domains: bool = True,
     ) -> None:
         super().__init__(config, ctx)
 
@@ -65,8 +64,6 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
         self.client = MojPublicationsAPIClient(
             config.base_url, config.default_contact_email, config.params
         )
-        if validate_domains:
-            self.client.validate_domains()
         self._id_to_domain_contact_mapping = self.client._id_to_domain_contact_mapping
         self.platform_name = "GOV.UK"
         self.platform_instance = "ministry-of-justice-publications"

--- a/ingestion/moj_statistical_publications_source/source.py
+++ b/ingestion/moj_statistical_publications_source/source.py
@@ -34,7 +34,7 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.utilities.time import datetime_to_ts_millis
 
-from ingestion.ingestion_utils import FindMojDataEntityTypes, format_domain_name
+from ingestion.ingestion_utils import FindMojDataEntityTypes
 
 from .api_client import MojPublicationsAPIClient
 from .config import MojPublicationsAPIConfig
@@ -221,16 +221,10 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
                         aspect=ContainerClass(container=parent_collection_urn),
                     )
                 )
-                domain = self._id_to_domain_contact_mapping.get(
-                    parent_collection_ids[0], {}
-                ).get("domain")
 
                 # because as is there won't always be an applicable domain (subject area)
                 # even within a colleciton
                 tags = [TagAssociationClass(tag="urn:li:tag:dc_display_in_catalogue")]
-                if domain:
-                    domain_name = format_domain_name(domain)
-                    tags.append(TagAssociationClass(tag=f"urn:li:tag:{domain_name}"))
 
                 subject_areas = self._id_to_domain_contact_mapping.get(
                     parent_collection_ids[0], {}

--- a/ingestion/moj_statistical_publications_source/source.py
+++ b/ingestion/moj_statistical_publications_source/source.py
@@ -64,7 +64,7 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
         self.client = MojPublicationsAPIClient(
             config.base_url, config.default_contact_email, config.params
         )
-        self._id_to_domain_contact_mapping = self.client._id_to_domain_contact_mapping
+        self._id_to_metadata_mapping = self.client._id_to_metadata_mapping
         self.platform_name = "GOV.UK"
         self.platform_instance = "ministry-of-justice-publications"
         self.access_requirements = config.access_requirements
@@ -205,7 +205,7 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
                 parent_collection_urn = mce_builder.make_container_urn(container_key)
                 custom_properties.update(
                     {
-                        "dc_team_email": self._id_to_domain_contact_mapping.get(
+                        "dc_team_email": self._id_to_metadata_mapping.get(
                             parent_collection_ids[0], {}
                         ).get("contact_email", self.client.default_contact_email)
                     }
@@ -222,7 +222,7 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
                 # there won't always be an applicable subject area, even within a collection
                 tags = [TagAssociationClass(tag="urn:li:tag:dc_display_in_catalogue")]
 
-                subject_areas = self._id_to_domain_contact_mapping.get(
+                subject_areas = self._id_to_metadata_mapping.get(
                     parent_collection_ids[0], {}
                 ).get("subject_areas")
 

--- a/ingestion/post_ingestion_checks.py
+++ b/ingestion/post_ingestion_checks.py
@@ -108,7 +108,7 @@ def create_query_input(platform: str) -> dict:
     return {
         "input": {
             "types": [],
-            "facets": ["_entityType", "tags", "domains", "owners"],
+            "facets": ["_entityType", "tags", "owners"],
             "orFilters": [
                 {
                     "and": [

--- a/ingestion/transformers/enrich_container_transformer.py
+++ b/ingestion/transformers/enrich_container_transformer.py
@@ -18,7 +18,6 @@ from datahub.metadata._schema_classes import (
 from datahub.metadata.schema_classes import MetadataChangeProposalClass
 
 from ingestion.utils import report_time
-from ingestion.ingestion_utils import domains_to_subject_areas
 
 URN_CONTAINER_PREFIX = "urn:li:container:"
 DATAOWNER = "DATAOWNER"
@@ -34,8 +33,7 @@ class EnrichContainerTransformerConfig(ConfigModel):
 
 
 class EnrichContainerTransformer(ContainerTransformer, metaclass=ABCMeta):
-    """Transformer that adds an owner, domain, and tag
-    for a provided container"""
+    """Transformer that adds an owner and tags for a provided container"""
 
     ctx: PipelineContext
     config: EnrichContainerTransformerConfig

--- a/tests/create_cadet_databases/test_source.py
+++ b/tests/create_cadet_databases/test_source.py
@@ -46,25 +46,20 @@ def test_tags(mock_datahub_graph):
     )
 
     assert set(courts_data_tags) == {
-        "urn:li:tag:Courts",
         "urn:li:tag:Courts and tribunals",
         "urn:li:tag:dc_display_in_catalogue",
     }
     assert set(probation_database_tags) == {
-        "urn:li:tag:Probation",
         "urn:li:tag:Prisons and probation",
         "urn:li:tag:dc_display_in_catalogue",
     }
     assert set(prison_database_tags) == {
-        "urn:li:tag:Prison",
         "urn:li:tag:Prisons and probation",
         "urn:li:tag:dc_display_in_catalogue",
     }
     assert set(ref_database_tags) == {
-        "urn:li:tag:General",
         "urn:li:tag:dc_display_in_catalogue",
     }
     assert set(hq_database_tags) == {
-        "urn:li:tag:HQ",
         "urn:li:tag:dc_display_in_catalogue",
     }

--- a/tests/test_assign_cadet_databases.py
+++ b/tests/test_assign_cadet_databases.py
@@ -49,13 +49,6 @@ class TestAssignCadetDatabasesTransformer:
     def test_pattern_add_dataset_domain_match_aspect_none(self, mock_datahub_graph):
         pipeline_context: PipelineContext = PipelineContext(run_id="abc")
         pipeline_context.graph = mock_datahub_graph(DatahubClientConfig)
-        expected_key = mcp_builder.DatabaseKey(
-            database="prison_database",
-            platform=PLATFORM,
-            instance=INSTANCE,
-            env=ENV,
-            backcompat_env_as_instance=True,
-        )
 
         output = run_dataset_transformer_pipeline(
             transformer_type=AssignCadetDatabases,

--- a/tests/test_assign_cadet_databases.py
+++ b/tests/test_assign_cadet_databases.py
@@ -34,18 +34,17 @@ class TestAssignCadetDatabasesTransformer:
             pipeline_context=pipeline_context,
         )
 
-        assert len(output) == 5
+        assert len(output) == 4
         assert output[0] is not None
         assert output[0].record is not None
         assert isinstance(output[0].record, MetadataChangeProposalWrapper)
         assert output[0].record.aspect is not None
         assert isinstance(output[0].record.aspect, models.GlobalTagsClass)
         assert output[0].record.aspect.tags == [
-            TagAssociationClass(tag=builder.make_tag_urn("Prison")),
             TagAssociationClass(tag=builder.make_tag_urn("Prisons and probation")),
         ]
-        assert isinstance(output[3].record.aspect, models.ContainerClass)
-        assert output[3].record.aspect.container == expected_key.as_urn()
+        assert isinstance(output[2].record.aspect, models.ContainerClass)
+        assert output[2].record.aspect.container == expected_key.as_urn()
 
     def test_pattern_add_dataset_domain_match_aspect_none(self, mock_datahub_graph):
         pipeline_context: PipelineContext = PipelineContext(run_id="abc")

--- a/tests/test_assign_cadet_databases.py
+++ b/tests/test_assign_cadet_databases.py
@@ -15,9 +15,7 @@ from ingestion.transformers.assign_cadet_databases import AssignCadetDatabases
 
 class TestAssignCadetDatabasesTransformer:
     def test_pattern_add_dataset_domain_match(self, mock_datahub_graph):
-        pipeline_context: PipelineContext = PipelineContext(
-            run_id="test_simple_add_dataset_domain"
-        )
+        pipeline_context: PipelineContext = PipelineContext(run_id="abc")
         pipeline_context.graph = mock_datahub_graph(DatahubClientConfig)
         expected_key = mcp_builder.DatabaseKey(
             database="prison_database",
@@ -50,9 +48,7 @@ class TestAssignCadetDatabasesTransformer:
         assert output[3].record.aspect.container == expected_key.as_urn()
 
     def test_pattern_add_dataset_domain_match_aspect_none(self, mock_datahub_graph):
-        pipeline_context: PipelineContext = PipelineContext(
-            run_id="test_simple_add_dataset_domain"
-        )
+        pipeline_context: PipelineContext = PipelineContext(run_id="abc")
         pipeline_context.graph = mock_datahub_graph(DatahubClientConfig)
         expected_key = mcp_builder.DatabaseKey(
             database="prison_database",

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -14,7 +14,6 @@ from datahub.metadata.schema_classes import (
 
 from ingestion.create_cadet_databases_source.config import CreateCadetDatabasesConfig
 from ingestion.create_cadet_databases_source.source import CreateCadetDatabases
-from ingestion.ingestion_utils import format_domain_name
 
 
 class TestCreateCadetDatabases:

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -7,7 +7,6 @@ from datahub.metadata.schema_classes import (
     ContainerPropertiesClass,
     CorpUserInfoClass,
     DataPlatformInstanceClass,
-    DomainsClass,
     GlobalTagsClass,
     StatusClass,
     SubTypesClass,
@@ -42,7 +41,6 @@ class TestCreateCadetDatabases:
         status_events = self.results_by_aspect_type[StatusClass]
         platform_events = self.results_by_aspect_type[DataPlatformInstanceClass]
         sub_types_events = self.results_by_aspect_type[SubTypesClass]
-        domains_events = self.results_by_aspect_type[DomainsClass]
         tags_events = self.results_by_aspect_type[GlobalTagsClass]
         user_creation_events = self.results_by_aspect_type[CorpUserInfoClass]
 

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -3,14 +3,7 @@ from collections import defaultdict
 import datahub.emitter.mce_builder as builder
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.common.subtypes import DatasetContainerSubTypes
-from datahub.metadata.schema_classes import (
-    ContainerPropertiesClass,
-    CorpUserInfoClass,
-    DataPlatformInstanceClass,
-    GlobalTagsClass,
-    StatusClass,
-    SubTypesClass,
-)
+from utils import group_metadata
 
 from ingestion.create_cadet_databases_source.config import CreateCadetDatabasesConfig
 from ingestion.create_cadet_databases_source.source import CreateCadetDatabases
@@ -25,50 +18,57 @@ class TestCreateCadetDatabases:
                 database_metadata_s3_uri="s3://test_bucket/prod/run_artefacts/latest/target/database_metadata.json",
             ),
         )
-        self.results = list(source.get_workunits())
-        self.results.sort(key=lambda event: event.metadata.entityUrn)
-
-        self.results_by_aspect_type = defaultdict(list)
-        for result in self.results:
-            aspect_type = type(result.metadata.aspect)
-            self.results_by_aspect_type[aspect_type].append(result)
+        self.results = group_metadata(source.get_workunits())
 
     def test_creating_domains_from_s3(self):
-        # Events are created for the following aspects per database:
-        # create container, update status, add platform, add subtype, associate container with domain, add tags
-        container_events = self.results_by_aspect_type[ContainerPropertiesClass]
-        status_events = self.results_by_aspect_type[StatusClass]
-        platform_events = self.results_by_aspect_type[DataPlatformInstanceClass]
-        sub_types_events = self.results_by_aspect_type[SubTypesClass]
-        tags_events = self.results_by_aspect_type[GlobalTagsClass]
-        user_creation_events = self.results_by_aspect_type[CorpUserInfoClass]
-
-        assert (
-            len(container_events) == len(sub_types_events) == len(platform_events) == 5
-        )
-
-        assert len(tags_events) == 6
-
-        assert container_events[0].metadata.aspect.customProperties.get("database")
-
-        assert (
-            platform_events[0].metadata.aspect.platform
-        ) == builder.make_data_platform_urn(platform="dbt")
-        assert (
-            DatasetContainerSubTypes.DATABASE
-            in sub_types_events[0].metadata.aspect.typeNames
-        )
-
-        user_urns = [event.metadata.entityUrn for event in user_creation_events]
-        assert user_urns == ["urn:li:corpuser:some.one", "urn:li:corpuser:some.team"]
-
-    def test_seeds_are_tagged_to_display_in_catalogue(self):
-        seed_tag_event = [
-            result
-            for result in self.results_by_aspect_type[GlobalTagsClass]
-            if result.metadata.entityType == "dataset"
+        urns = [
+            "urn:li:container:27c5c4df57bf429bf9e56e51b30003ed",
+            "urn:li:container:ea9744b8004d93b716687bab12438c90",
+            "urn:li:container:48e5e41ce461da41f0333b67a322fb99",
+            "urn:li:container:1e7a7a180ed4f1215bff62f4ce93993e",
+            "urn:li:container:b17e173b8950dee2415a3119fb7c9d12",
         ]
-        assert seed_tag_event[0].metadata.entityType == "dataset"
-        assert seed_tag_event[0].metadata.changeType == "UPSERT"
-        tag_names = {tag.tag for tag in seed_tag_event[0].metadata.aspect.tags}
-        assert "urn:li:tag:dc_display_in_catalogue" in tag_names
+
+        for urn in urns:
+            assert urn in self.results
+            aspects = self.results[urn]
+
+            # Events are created for the following aspects per database:
+            # create container, update status, add platform, add subtype, associate container with domain, add tags
+            container_events = aspects["containerProperties"]
+            status_events = aspects["status"]
+            platform_events = aspects["dataPlatformInstance"]
+            sub_types_events = aspects["subTypes"]
+            tags_events = aspects["globalTags"]
+
+            assert (
+                len(container_events)
+                == len(status_events)
+                == len(sub_types_events)
+                == len(platform_events)
+                == len(tags_events)
+                == 1
+            )
+
+            assert container_events[0].customProperties.get("database")
+
+            assert (platform_events[0].platform) == builder.make_data_platform_urn(
+                platform="dbt"
+            )
+            assert DatasetContainerSubTypes.DATABASE in sub_types_events[0].typeNames
+
+        assert self.results.get("urn:li:corpuser:some.one", {}).get("corpUserInfo")
+        assert self.results.get("urn:li:corpuser:some.team", {}).get("corpUserInfo")
+
+    def test_seeds_are_tagged_to_display_in_catalogue_and_subject_area(self):
+        tag_names = [
+            tag.tag
+            for tagAspect in self.results[
+                "urn:li:container:1e7a7a180ed4f1215bff62f4ce93993e"
+            ]["globalTags"]
+            for tag in tagAspect.tags
+        ]
+        assert set(tag_names) == {
+            "urn:li:tag:dc_display_in_catalogue",
+            "urn:li:tag:Courts and tribunals",
+        }

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -7,7 +7,6 @@ from datahub.metadata.schema_classes import (
     ContainerPropertiesClass,
     CorpUserInfoClass,
     DataPlatformInstanceClass,
-    DomainPropertiesClass,
     DomainsClass,
     GlobalTagsClass,
     StatusClass,
@@ -37,10 +36,6 @@ class TestCreateCadetDatabases:
             self.results_by_aspect_type[aspect_type].append(result)
 
     def test_creating_domains_from_s3(self):
-        domain_creation_events = self.results_by_aspect_type[DomainPropertiesClass]
-        domains = [event.metadata.aspect.name for event in domain_creation_events]
-        assert domains == ["Courts", "HQ", "Prison", "Probation"]
-
         # Events are created for the following aspects per database:
         # create container, update status, add platform, add subtype, associate container with domain, add tags
         container_events = self.results_by_aspect_type[ContainerPropertiesClass]
@@ -54,8 +49,6 @@ class TestCreateCadetDatabases:
         assert (
             len(container_events) == len(sub_types_events) == len(platform_events) == 5
         )
-
-        assert len(domains_events) == 10
 
         assert len(tags_events) == 6
 

--- a/tests/test_create_cadet_domains.py
+++ b/tests/test_create_cadet_domains.py
@@ -61,19 +61,6 @@ class TestCreateCadetDatabases:
             DatasetContainerSubTypes.DATABASE
             in sub_types_events[0].metadata.aspect.typeNames
         )
-        assert (
-            container_events[0].metadata.entityUrn
-            == domains_events[0].metadata.entityUrn
-        )
-        expected_domain = (
-            container_events[0]
-            .metadata.aspect.customProperties.get("database")
-            .split("_")[0]
-        )
-        assert (
-            builder.make_domain_urn(format_domain_name(expected_domain))
-            in domains_events[0].metadata.aspect.domains
-        )
 
         user_urns = [event.metadata.entityUrn for event in user_creation_events]
         assert user_urns == ["urn:li:corpuser:some.one", "urn:li:corpuser:some.team"]
@@ -88,14 +75,3 @@ class TestCreateCadetDatabases:
         assert seed_tag_event[0].metadata.changeType == "UPSERT"
         tag_names = {tag.tag for tag in seed_tag_event[0].metadata.aspect.tags}
         assert "urn:li:tag:dc_display_in_catalogue" in tag_names
-
-    def test_datasets_are_assigned_to_domains(self):
-        # This is the first event which should associate a dataset with a domain
-        dataset_with_domains = [
-            result
-            for result in self.results_by_aspect_type[DomainsClass]
-            if result.metadata.entityType == "dataset"
-        ]
-        assert dataset_with_domains[0].metadata.entityType == "dataset"
-        assert dataset_with_domains[0].metadata.changeType == "UPSERT"
-        assert dataset_with_domains[0].metadata.aspect.ASPECT_NAME == "domains"

--- a/tests/test_enrich_container_transformer.py
+++ b/tests/test_enrich_container_transformer.py
@@ -17,9 +17,7 @@ from ingestion.transformers.enrich_container_transformer import (
 class TestEnrichContainerTransformer:
     def test_pattern_add_dataset_domain_match(self, mock_datahub_graph):
 
-        pipeline_context: PipelineContext = PipelineContext(
-            run_id="test_simple_add_dataset_domain"
-        )
+        pipeline_context: PipelineContext = PipelineContext(run_id="abc")
         graph = mock_datahub_graph(DatahubClientConfig)
         graph.get_aspect = MagicMock(
             return_value=ContainerPropertiesClass(name="foo", customProperties=None)

--- a/tests/test_ingestion_utils.py
+++ b/tests/test_ingestion_utils.py
@@ -2,21 +2,7 @@ import json
 
 import pytest
 
-from ingestion.ingestion_utils import format_domain_name, parse_database_and_table_names
-
-
-@pytest.mark.parametrize(
-    "original,expected",
-    [
-        ("foo", "Foo"),
-        ("electronic_monitoring", "Electronic monitoring"),
-        ("opg", "OPG"),
-        ("aBcDe", "Abcde"),
-    ],
-)
-def test_format_domain_name(original, expected):
-    assert format_domain_name(original) == expected
-
+from ingestion.ingestion_utils import parse_database_and_table_names
 
 with open("tests/data/manifest.json") as f:
     test_manifest = json.load(f)

--- a/tests/test_moj_statistical_publications_source.py
+++ b/tests/test_moj_statistical_publications_source.py
@@ -72,7 +72,7 @@ def mock_justice_publication_api(default_contact_email, publication_mappings):
         # these are likely to change so we need to mock them
         with patch.object(
             source,
-            "_id_to_domain_contact_mapping",
+            "_id_to_metadata_mapping",
             new=publication_mappings,
         ):
             results = list(source.get_workunits())

--- a/tests/test_moj_statistical_publications_source.py
+++ b/tests/test_moj_statistical_publications_source.py
@@ -8,7 +8,6 @@ from datahub.metadata.schema_classes import (
     ContainerPropertiesClass,
     DataPlatformInstanceClass,
     DatasetPropertiesClass,
-    DomainsClass,
     GlobalTagsClass,
     StatusClass,
     SubTypesClass,
@@ -99,7 +98,6 @@ def test_workunits(mock_justice_publication_api):
     dataset_events = workunits_by_aspect_type[DatasetPropertiesClass]
     platform_events = workunits_by_aspect_type[DataPlatformInstanceClass]
     sub_types_events = workunits_by_aspect_type[SubTypesClass]
-    domains_events = workunits_by_aspect_type[DomainsClass]
     tags_events = workunits_by_aspect_type[GlobalTagsClass]
 
     # We expect 51 containers

--- a/tests/test_moj_statistical_publications_source.py
+++ b/tests/test_moj_statistical_publications_source.py
@@ -68,7 +68,6 @@ def mock_justice_publication_api(default_contact_email, publication_mappings):
                     ],
                 ),
             ),
-            validate_domains=False,
         )
         # these are likely to change so we need to mock them
         with patch.object(


### PR DESCRIPTION
This PR removes everything that adds domain aspect metadata, and renames variables that refer to DataHub domains.

The remaining references to "domain" refer to CaDeT domains - i.e. the domains used in the directory structure of CaDeT.

In addition to removing the domain association in DataHub, this also removes some redundant tags. Before, we were creating tags that exactly matched the CaDeT domains (e.g. "courts", "prison") in addition to the top level domains we actually use ("Courts and tribunals", "Prisons and probation"). We are planning on adding more fine grained subject tags, but instead of having special logic for that here, we will add the tags at source in the CaDeT repo.