### PR TITLE
refactor: create WorkunitInspector helper for tests

### DIFF
--- a/tests/create_cadet_databases/test_source.py
+++ b/tests/create_cadet_databases/test_source.py
@@ -2,7 +2,7 @@ from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StatefulStaleMetadataRemovalConfig,
 )
-from utils import extract_tag_names, group_metadata
+from utils import WorkunitInspector
 
 from ingestion.create_cadet_databases_source.source import (
     CreateCadetDatabases,
@@ -22,28 +22,31 @@ def run_source(mock_datahub_graph):
         ctx=PipelineContext(run_id="abc", graph=mock_datahub_graph),
     )
 
-    return group_metadata(source.get_workunits())
+    return WorkunitInspector(source.get_workunits())
 
 
 def test_tags(mock_datahub_graph):
     metadata = run_source(mock_datahub_graph)
 
-    courts_data_tags = extract_tag_names(
-        metadata["urn:li:container:1e7a7a180ed4f1215bff62f4ce93993e"]["globalTags"]
-    )
-    probation_database_tags = extract_tag_names(
-        metadata["urn:li:container:ea9744b8004d93b716687bab12438c90"]["globalTags"]
-    )
-    prison_database_tags = extract_tag_names(
-        metadata["urn:li:container:b17e173b8950dee2415a3119fb7c9d12"]["globalTags"]
-    )
+    courts_data_tags = metadata.entity(
+        "urn:li:container:1e7a7a180ed4f1215bff62f4ce93993e"
+    ).tag_names
 
-    ref_database_tags = extract_tag_names(
-        metadata["urn:li:container:27c5c4df57bf429bf9e56e51b30003ed"]["globalTags"]
-    )
-    hq_database_tags = extract_tag_names(
-        metadata["urn:li:container:48e5e41ce461da41f0333b67a322fb99"]["globalTags"]
-    )
+    probation_database_tags = metadata.entity(
+        "urn:li:container:ea9744b8004d93b716687bab12438c90"
+    ).tag_names
+
+    prison_database_tags = metadata.entity(
+        "urn:li:container:b17e173b8950dee2415a3119fb7c9d12"
+    ).tag_names
+
+    ref_database_tags = metadata.entity(
+        "urn:li:container:27c5c4df57bf429bf9e56e51b30003ed"
+    ).tag_names
+
+    hq_database_tags = metadata.entity(
+        "urn:li:container:48e5e41ce461da41f0333b67a322fb99"
+    ).tag_names
 
     assert set(courts_data_tags) == {
         "urn:li:tag:Courts and tribunals",


### PR DESCRIPTION
This is not essential, but some of our ingestion tests feel quite convoluted, so I've had another go at refactoring them. 

My idea is to introduce a helper class called `WorkunitInspector`, that allows you to extract specific entities/aspects from the metadata attached to the workunits, e.g.

`WorkunitInspector(workunits).entity(urn).aspect('chartInfo')`

If the aspect is missing or there are more than one of the same aspect, then the above will raise an AssertionError.

You can call `assert WorkunitInspector(workunits).entity(urn)` to check whether the urn is present in the metadata without specifying an aspect.

Also, `WorkunitInspector(workunits).entity(urn).tag_names` gives you a set of all the tag names associated with an entity.