### PR TITLE
Update postgres username from github secrets and pass into the workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,6 +24,7 @@ jobs:
       postgres_host: ${{ secrets.POSTGRES_HOST}}
       postgres_client_host: ${{ secrets.POSTGRES_CLIENT_HOST }}
       postgres_url: ${{ secrets.POSTGRES_URL }}
+      postgres_username: ${{ secrets.POSTGRES_USERNAME }}
       opensearch_proxy_host: ${{ secrets.OPENSEARCH_PROXY_HOST }}
       azure_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
       limit_whitelist: ${{ secrets.LIMIT_WHITELIST }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,6 +26,7 @@ jobs:
       postgres_url: ${{ secrets.POSTGRES_URL }}
       postgres_username: ${{ secrets.POSTGRES_USERNAME }}
       postgres_password: ${{ secrets.POSTGRES_PASSWORD }}
+      postgres_db_name: ${{ secrets.POSTGRES_DB_NAME }}
       opensearch_proxy_host: ${{ secrets.OPENSEARCH_PROXY_HOST }}
       azure_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
       limit_whitelist: ${{ secrets.LIMIT_WHITELIST }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,6 +25,7 @@ jobs:
       postgres_client_host: ${{ secrets.POSTGRES_CLIENT_HOST }}
       postgres_url: ${{ secrets.POSTGRES_URL }}
       postgres_username: ${{ secrets.POSTGRES_USERNAME }}
+      postgres_password: ${{ secrets.POSTGRES_PASSWORD }}
       opensearch_proxy_host: ${{ secrets.OPENSEARCH_PROXY_HOST }}
       azure_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
       limit_whitelist: ${{ secrets.LIMIT_WHITELIST }}

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -37,6 +37,9 @@ on:
       postgres_url:
         description: "URI including the scheme designator (prefix) and database name"
         required: true
+      postgres_username:
+        description: "username for the metadata database"
+        required: true
       opensearch_proxy_host:
         description: "domain address to reach opensearch"
         required: true
@@ -175,6 +178,7 @@ jobs:
           POSTGRES_CLIENT_HOST: ${{ secrets.postgres_client_host }}
           POSTGRES_HOST: ${{ secrets.postgres_host }}
           POSTGRES_URL: ${{ secrets.postgres_url }}
+          POSTGRES_USERNAME: ${{ secrets.postgres_username }}
           RELEASE_NAME: datahub
           FRONTEND_FULLNAME: datahub-frontend-${{ inputs.env }}
         # if many env-specific variables need setting, add --values files after 'base'
@@ -198,6 +202,7 @@ jobs:
           --set global.sql.datasource.host=${POSTGRES_HOST} \
           --set global.sql.datasource.hostForpostgresqlClient=${POSTGRES_CLIENT_HOST} \
           --set global.sql.datasource.url=${POSTGRES_URL}
+          --set global.sql.datasource.username=${POSTGRES_USERNAME}
 
       - name: allow CP prometheus scraping 
         shell: bash

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -43,6 +43,9 @@ on:
       postgres_password:
         description: "password for the metadata database"
         required: true
+      postgres_db_name:
+        description: "name of the metadata database"
+        required: true
       opensearch_proxy_host:
         description: "domain address to reach opensearch"
         required: true
@@ -183,6 +186,7 @@ jobs:
           POSTGRES_URL: ${{ secrets.postgres_url }}
           POSTGRES_USERNAME: ${{ secrets.postgres_username }}
           POSTGRES_PASSWORD: ${{ secrets.postgres_password }}
+          POSTGRES_DB_NAME: ${{ secrets.postgres_db_name }}
           RELEASE_NAME: datahub
           FRONTEND_FULLNAME: datahub-frontend-${{ inputs.env }}
         # if many env-specific variables need setting, add --values files after 'base'
@@ -208,6 +212,7 @@ jobs:
           --set global.sql.datasource.url=${POSTGRES_URL}
           --set global.sql.datasource.username=${POSTGRES_USERNAME}
           --set global.sql.datasource.password=${POSTGRES_PASSWORD}
+          --set global.sql.datasource.extraEnvs[0].value=${POSTGRES_DB_NAME}
 
       - name: allow CP prometheus scraping 
         shell: bash

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -40,6 +40,9 @@ on:
       postgres_username:
         description: "username for the metadata database"
         required: true
+      postgres_password:
+        description: "password for the metadata database"
+        required: true
       opensearch_proxy_host:
         description: "domain address to reach opensearch"
         required: true
@@ -179,6 +182,7 @@ jobs:
           POSTGRES_HOST: ${{ secrets.postgres_host }}
           POSTGRES_URL: ${{ secrets.postgres_url }}
           POSTGRES_USERNAME: ${{ secrets.postgres_username }}
+          POSTGRES_PASSWORD: ${{ secrets.postgres_password }}
           RELEASE_NAME: datahub
           FRONTEND_FULLNAME: datahub-frontend-${{ inputs.env }}
         # if many env-specific variables need setting, add --values files after 'base'
@@ -203,6 +207,7 @@ jobs:
           --set global.sql.datasource.hostForpostgresqlClient=${POSTGRES_CLIENT_HOST} \
           --set global.sql.datasource.url=${POSTGRES_URL}
           --set global.sql.datasource.username=${POSTGRES_USERNAME}
+          --set global.sql.datasource.password=${POSTGRES_PASSWORD}
 
       - name: allow CP prometheus scraping 
         shell: bash

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -622,10 +622,7 @@ global:
       password: ""
       extraEnvs:
         - name: "DATAHUB_DB_NAME"
-          valueFrom:
-            secretKeyRef:
-              name: rds-postgresql-instance-output
-              key: database_name
+          value: ""
 
   datahub:
     version: v0.14.1

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -618,9 +618,7 @@ global:
       # url is format "jdbc:postgresql://{host}/{database_name}"
       url: ""
       driver: "org.postgresql.Driver"
-      username:
-        secretRef: rds-postgresql-instance-output
-        secretKey: database_username
+      username: ""
       password:
         secretRef: rds-postgresql-instance-output
         secretKey: database_password

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -619,9 +619,7 @@ global:
       url: ""
       driver: "org.postgresql.Driver"
       username: ""
-      password:
-        secretRef: rds-postgresql-instance-output
-        secretKey: database_password
+      password: ""
       extraEnvs:
         - name: "DATAHUB_DB_NAME"
           valueFrom:

--- a/scripts/k8s-rds-secrets-to-github-secrets.sh
+++ b/scripts/k8s-rds-secrets-to-github-secrets.sh
@@ -53,6 +53,7 @@ RDS_SECRET_YAML=$(kubectl -n "$KUBE_NAMESPACE" get secret $RDS_SECRET_NAME -o ya
 RDS_INSTANCE_ADDRESS=$(echo "$RDS_SECRET_YAML" | grep 'rds_instance_address:' | awk '{print $2}' | base64 -d)
 RDS_INSTANCE_ENDPOINT=$(echo "$RDS_SECRET_YAML" | grep 'rds_instance_endpoint:' | awk '{print $2}' | base64 -d)
 DATABASE_USERNAME=$(echo "$RDS_SECRET_YAML" | grep 'database_username:' | awk '{print $2}' | base64 -d)
+DATABASE_PASSWORD=$(echo "$RDS_SECRET_YAML" | grep 'database_password:' | awk '{print $2}' | base64 -d)
 DB_NAME=$(echo "$RDS_SECRET_YAML" | grep 'database_name:' | awk '{print $2}' | base64 -d)
 RDS_URL="jdbc:postgresql://${RDS_INSTANCE_ENDPOINT}/${DB_NAME}"
 
@@ -68,6 +69,7 @@ if [[ $DRY_RUN == true ]]; then
   echo "- POSTGRES_HOST=$RDS_INSTANCE_ENDPOINT"
   echo "- POSTGRES_URL=$RDS_URL"
   echo "- POSTGRES_USERNAME=$DATABASE_USERNAME"
+  echo "- POSTGRES_PASSWORD=$DATABASE_PASSWORD"
   echo "- OPENSEARCH_PROXY_HOST=$OS_PROXY_URL"
 else
   # Set GitHub secrets (assuming you have GitHub CLI installed and configured)
@@ -85,6 +87,10 @@ else
     --repo $GITHUB_REPO 
   gh secret set POSTGRES_USERNAME \
     --body $DATABASE_USERNAME \
+    --env $GITHUB_ENV_NAME \
+    --repo $GITHUB_REPO
+  gh secret set POSTGRES_PASSWORD \
+    --body $DATABASE_PASSWORD \
     --env $GITHUB_ENV_NAME \
     --repo $GITHUB_REPO
   gh secret set OPENSEARCH_PROXY_HOST \

--- a/scripts/k8s-rds-secrets-to-github-secrets.sh
+++ b/scripts/k8s-rds-secrets-to-github-secrets.sh
@@ -54,8 +54,8 @@ RDS_INSTANCE_ADDRESS=$(echo "$RDS_SECRET_YAML" | grep 'rds_instance_address:' | 
 RDS_INSTANCE_ENDPOINT=$(echo "$RDS_SECRET_YAML" | grep 'rds_instance_endpoint:' | awk '{print $2}' | base64 -d)
 DATABASE_USERNAME=$(echo "$RDS_SECRET_YAML" | grep 'database_username:' | awk '{print $2}' | base64 -d)
 DATABASE_PASSWORD=$(echo "$RDS_SECRET_YAML" | grep 'database_password:' | awk '{print $2}' | base64 -d)
-DB_NAME=$(echo "$RDS_SECRET_YAML" | grep 'database_name:' | awk '{print $2}' | base64 -d)
-RDS_URL="jdbc:postgresql://${RDS_INSTANCE_ENDPOINT}/${DB_NAME}"
+DATABASE_NAME=$(echo "$RDS_SECRET_YAML" | grep 'database_name:' | awk '{print $2}' | base64 -d)
+RDS_URL="jdbc:postgresql://${RDS_INSTANCE_ENDPOINT}/${DATABASE_NAME}"
 
 OS_SECRET_YAML=$(kubectl -n "$KUBE_NAMESPACE" get secret $OS_SECRET_NAME -o yaml)
 OS_PROXY_URL=$(echo "$OS_SECRET_YAML" | grep 'proxy_url:' | awk '{print $2}' | base64 -d)
@@ -70,6 +70,7 @@ if [[ $DRY_RUN == true ]]; then
   echo "- POSTGRES_URL=$RDS_URL"
   echo "- POSTGRES_USERNAME=$DATABASE_USERNAME"
   echo "- POSTGRES_PASSWORD=$DATABASE_PASSWORD"
+  echo "- POSTGRES_DB_NAME=$DATABASE_NAME"
   echo "- OPENSEARCH_PROXY_HOST=$OS_PROXY_URL"
 else
   # Set GitHub secrets (assuming you have GitHub CLI installed and configured)
@@ -91,6 +92,10 @@ else
     --repo $GITHUB_REPO
   gh secret set POSTGRES_PASSWORD \
     --body $DATABASE_PASSWORD \
+    --env $GITHUB_ENV_NAME \
+    --repo $GITHUB_REPO
+  gh secret set POSTGRES_DB_NAME \
+    --body $DATABASE_NAME \
     --env $GITHUB_ENV_NAME \
     --repo $GITHUB_REPO
   gh secret set OPENSEARCH_PROXY_HOST \


### PR DESCRIPTION
The Upgrade of Datahub to v0.15 appears to have an issue with accessing the value for the database username from a secret store. Possible similar issue with chart version released after v0.14.1 - https://github.com/acryldata/datahub-helm/issues/531

This change stores username, password and database name as gh secrets and populates them in the workflow, removing the reliance on obtaining them from the secret store.