### PR TITLE
fmd1389: Add transparency type publications

### DIFF
--- a/ingestion/moj_publications.yaml
+++ b/ingestion/moj_publications.yaml
@@ -5,7 +5,8 @@ source:
     base_url: "https://gov.uk/api"
     default_contact_email: statistics.enquiries@justice.gsi.gov.uk
     collections_to_exclude: [
-      "offender-management-statistics-quarterly--3"
+      "offender-management-statistics-quarterly--3",
+      "national-offender-management-service-workforce-statistics",
     ]
     access_requirements: You are free to re-use the data internally or externally without requesting permission.
     params:

--- a/ingestion/moj_publications.yaml
+++ b/ingestion/moj_publications.yaml
@@ -9,10 +9,17 @@ source:
     ]
     access_requirements: You are free to re-use the data internally or externally without requesting permission.
     params:
-      filter_organisations: [ministry-of-justice]
+      filter_organisations: [
+        "ministry-of-justice",
+        "hm-prison-and-probation-service",
+        "probation-service",
+        "hm-prison-service",
+        "crime-justice-and-law",
+      ]
       filter_content_store_document_type: [
           "national_statistics",
-          "official_statistics"
+          "official_statistics",
+          "transparency"
       ]
     stateful_ingestion:
       enabled: true

--- a/ingestion/moj_statistical_publications_source/api_client.py
+++ b/ingestion/moj_statistical_publications_source/api_client.py
@@ -84,7 +84,7 @@ class MojPublicationsAPIClient:
             # for each collection
             link = collection.get("link")
             if not link:
-                logging.error(f"{collection=} does not have a link")
+                logging.warning(f"{collection=} does not have a link and will be skipped")
                 continue
             content_api_url = os.path.join(
                 self.base_url, f"content/{link}"

--- a/ingestion/moj_statistical_publications_source/api_client.py
+++ b/ingestion/moj_statistical_publications_source/api_client.py
@@ -87,7 +87,7 @@ class MojPublicationsAPIClient:
                 logging.warning(f"{collection=} does not have a link and will be skipped")
                 continue
             content_api_url = os.path.join(
-                self.base_url, "content", link
+                self.base_url, f"content/{link}"
             )
             content_response = self.session.get(content_api_url).json()
             collection["description"] = content_response.get("description")

--- a/ingestion/moj_statistical_publications_source/api_client.py
+++ b/ingestion/moj_statistical_publications_source/api_client.py
@@ -87,7 +87,7 @@ class MojPublicationsAPIClient:
                 logging.warning(f"{collection=} does not have a link and will be skipped")
                 continue
             content_api_url = os.path.join(
-                self.base_url, f"content/{link}"
+                self.base_url, "content", link
             )
             content_response = self.session.get(content_api_url).json()
             collection["description"] = content_response.get("description")

--- a/ingestion/moj_statistical_publications_source/api_client.py
+++ b/ingestion/moj_statistical_publications_source/api_client.py
@@ -82,8 +82,12 @@ class MojPublicationsAPIClient:
         for collection in unique_collections:
             # descriptions and last updated dates need to be fetched from the content API
             # for each collection
+            link = collection.get("link")
+            if not link:
+                logging.error(f"{collection=} does not have a link")
+                continue
             content_api_url = os.path.join(
-                self.base_url, f"content/{collection['link']}"
+                self.base_url, f"content/{link}"
             )
             content_response = self.session.get(content_api_url).json()
             collection["description"] = content_response.get("description")

--- a/ingestion/moj_statistical_publications_source/source.py
+++ b/ingestion/moj_statistical_publications_source/source.py
@@ -188,13 +188,16 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
 
                 # We'd need to explore a different approach to include multiple collection association
 
-                # There are 133 in mulitple collections at time of writing, about 10%
-                parent_collection_titles = [
-                    dc["title"] for dc in publication["document_collections"]
-                ]
-                parent_collection_ids = [
-                    dc["slug"] for dc in publication["document_collections"]
-                ]
+                # There are 133 in multiple collections at time of writing, about 10%
+                parent_collection_ids, parent_collection_titles = [], []
+                for document_collection in publication["document_collections"]:
+                    if "title" not in document_collection:
+                        logging.warning(
+                            f"Collection {document_collection} does not have a title and will be skipped"
+                        )
+                        continue
+                    parent_collection_ids.append(document_collection.get("slug"))
+                    parent_collection_titles.append(document_collection.get("title"))
 
                 container_key = mcp_builder.DatabaseKey(
                     database=parent_collection_titles[0],

--- a/ingestion/moj_statistical_publications_source/source.py
+++ b/ingestion/moj_statistical_publications_source/source.py
@@ -114,8 +114,10 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
             "security_classification": "Official - For public release",
         }
         for collection in collections_metadata:
-            last_modified_date = datetime.datetime.fromisoformat(
-                collection.get("last_updated", "")
+            last_modified_date = collection.get("last_updated")
+            last_modified_datetime_in_ms = (
+                datetime_to_ts_millis(datetime.datetime.fromisoformat(last_modified_date))
+                if last_modified_date else None
             )
 
             custom_properties["dc_team_email"] = collection.get(
@@ -143,7 +145,7 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
                 external_url=urljoin(self.client.base_url, collection.get("link")),
                 description=collection.get("description"),
                 created=None,
-                last_modified=datetime_to_ts_millis(last_modified_date),
+                last_modified=last_modified_datetime_in_ms,
                 tags=tags,
                 owner_urn=None,
                 qualified_name=collection.get("slug"),


### PR DESCRIPTION
A user flagged that we don't ingest "End of custody" data - I have made the ingestions for publications more permissive to include it, and hopefully head off any other missing publications!

I've had to exclude any datasets in collections we don't want as it was causing an ingestion issue - there was a collection with just a slug and no title from the API.