### PR TITLE
feat: add tag association for display in catalogue

### DIFF
--- a/ingestion/moj_statistical_publications_source/source.py
+++ b/ingestion/moj_statistical_publications_source/source.py
@@ -236,6 +236,7 @@ class MojPublicationsAPISource(StatefulIngestionSourceBase):
                     )
 
             else:
+                tags = [TagAssociationClass(tag="urn:li:tag:dc_display_in_catalogue")]
                 custom_properties["dc_team_email"] = self.client.default_contact_email
 
             # add dataset properties


### PR DESCRIPTION
Looks like entities with no document collections aren't assigned any tags