### PR TITLE
Check cadet manifest and catalog exist before ingesting

### DIFF
--- a/.github/workflows/ingest-cadet-metadata.yml
+++ b/.github/workflows/ingest-cadet-metadata.yml
@@ -61,8 +61,10 @@ jobs:
           role-duration-seconds: 14400
           aws-region: ${{ inputs.ECR_REGION }}
 
-      - name: Check cadet manifest exists
-        run: aws s3 ls ${{ inputs.S3_TARGET_LOCATION }}/manifest.json
+      - name: Check cadet manifest and catalog exist
+        run: |
+          aws s3 ls ${{ inputs.S3_TARGET_LOCATION }}/manifest.json
+          aws s3 ls ${{ inputs.S3_TARGET_LOCATION }}/catalog.json
 
       - name: cache poetry install
         uses: actions/cache@v4

--- a/.github/workflows/ingest-cadet-metadata.yml
+++ b/.github/workflows/ingest-cadet-metadata.yml
@@ -61,6 +61,9 @@ jobs:
           role-duration-seconds: 14400
           aws-region: ${{ inputs.ECR_REGION }}
 
+      - name: Check cadet manifest exists
+        run: aws s3 ls ${{ inputs.S3_TARGET_LOCATION }}/manifest.json
+
       - name: cache poetry install
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
CaDeT's deploy docs workflow often fails unnoticed for a while. The manifest file is archived after being 2 weeks old, and our ingestions silently fail as there's nothing to ingest. This simple check should result in an explicit fail if no manifest is present.