### PR TITLE
feat: add glue ingestion configuration for xhibit preprocessed data

### DIFF
--- a/ingestion/glue_common_platform.yaml
+++ b/ingestion/glue_common_platform.yaml
@@ -3,7 +3,7 @@ source:
   config:
     aws_region: "eu-west-1"
     database_pattern:
-      allow: ["xhibit_preprocessed$"]
+      allow: ["common_platform_dev_sdp_v3$"]
     extract_owners: False
     extract_transforms: False
 
@@ -16,7 +16,7 @@ transformers:
         - "urn:li:tag:Criminal courts"
   - type: "ingestion.transformers.enrich_container_transformer.EnrichContainerTransformer"
     config:
-      data_custodian: "murdo"
+      data_custodian: "${COURTS_CRIMINAL_TECHNICAL_CONTACT}"
       subject_areas:
         - Criminal courts
         - Courts and tribunals
@@ -27,12 +27,12 @@ transformers:
         dc_access_requirements: https://user-guidance.analytical-platform.service.justice.gov.uk/tools/create-a-derived-table/database-access/#database-access
         refresh_period: Weekly
         security_classification: Official-Sensitive
-  # - type: "simple_add_dataset_ownership"
-  #   config:
-  #     semantics: OVERWRITE
-  #     ownership_type: "DATAOWNER"
-  #     owner_urns:
-  #       - "thomas.hepworth@digital.justice.gov.uk"
+  - type: "simple_add_dataset_ownership"
+    config:
+      semantics: OVERWRITE
+      ownership_type: "DATAOWNER"
+      owner_urns:
+        - "${COURTS_CRIMINAL_TECHNICAL_CONTACT}"
   - type: "simple_add_dataset_properties"
     config:
       semantics: OVERWRITE # OVERWRITE is default behaviour

--- a/ingestion/glue_xhibit_preprocessed.yaml
+++ b/ingestion/glue_xhibit_preprocessed.yaml
@@ -3,7 +3,7 @@ source:
   config:
     aws_region: "eu-west-1"
     database_pattern:
-      allow: ["common_platform_dev_sdp_v3$"]
+      allow: ["xhibit_preprocessed$"]
     extract_owners: False
     extract_transforms: False
 

--- a/ingestion/glue_xhibit_preprocessed.yaml
+++ b/ingestion/glue_xhibit_preprocessed.yaml
@@ -1,0 +1,45 @@
+source:
+  type: glue
+  config:
+    aws_region: "eu-west-1"
+    database_pattern:
+      allow: ["xhibit_preprocessed$"]
+    extract_owners: False
+    extract_transforms: False
+
+transformers:
+  - type: "simple_add_dataset_tags"
+    config:
+      tag_urns:
+        - "urn:li:tag:dc_display_in_catalogue"
+        - "urn:li:tag:Courts and tribunals"
+        - "urn:li:tag:Criminal courts"
+  - type: "ingestion.transformers.enrich_container_transformer.EnrichContainerTransformer"
+    config:
+      data_custodian: "murdo"
+      subject_areas:
+        - Criminal courts
+        - Courts and tribunals
+      properties:
+        dc_slack_channel_name: "#criminal-courts-databases"
+        dc_slack_channel_url: https://moj.enterprise.slack.com/archives/CH935DZGS
+        dc_where_to_access_dataset: AnalyticalPlatform
+        dc_access_requirements: https://user-guidance.analytical-platform.service.justice.gov.uk/tools/create-a-derived-table/database-access/#database-access
+        refresh_period: Weekly
+        security_classification: Official-Sensitive
+  # - type: "simple_add_dataset_ownership"
+  #   config:
+  #     semantics: OVERWRITE
+  #     ownership_type: "DATAOWNER"
+  #     owner_urns:
+  #       - "thomas.hepworth@digital.justice.gov.uk"
+  - type: "simple_add_dataset_properties"
+    config:
+      semantics: OVERWRITE # OVERWRITE is default behaviour
+      properties:
+        dc_slack_channel_name: "#criminal-courts-databases"
+        dc_slack_channel_url: https://moj.enterprise.slack.com/archives/CH935DZGS
+        dc_where_to_access_dataset: AnalyticalPlatform
+        dc_access_requirements: https://user-guidance.analytical-platform.service.justice.gov.uk/tools/create-a-derived-table/database-access/#database-access
+        refresh_period: Weekly
+        security_classification: Official-Sensitive


### PR DESCRIPTION
* Ingest raw common platform data from glue
* Ingest preprocessed xhibit from glue

Both of these databases are defined in airflow in code, which is where metadata changes should go. `PLACEHOLDER_TECHNICAL_CONTACT` is my urn in datahub. We still have the code from data custodians 🤷 