### PR TITLE
Make containers higher weight in search results

### DIFF
--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -465,6 +465,11 @@ global:
                           value: true
                     weight: 2.0
                   - filter:
+                      prefix:
+                        urn:
+                          value: 'urn:li:container:'
+                    weight: 1.5
+                  - filter:
                       term:
                         hasDescription:
                           value: true

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -468,7 +468,7 @@ global:
                       prefix:
                         urn:
                           value: 'urn:li:container:'
-                    weight: 1.5
+                    weight: 2.0
                   - filter:
                       term:
                         hasDescription:

--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -468,7 +468,7 @@ global:
                       prefix:
                         urn:
                           value: 'urn:li:container:'
-                    weight: 2.0
+                    weight: 3.0
                   - filter:
                       term:
                         hasDescription:


### PR DESCRIPTION
https://datahubproject.io/docs/how/search/#example-4-entity-ranking

Our most frequent searches are for databases like nomis or caseman. Currently you have to scroll down to click the database, so this will mean users find their result faster.