### PR TITLE
Fix: add modsec bypass rule for nomis_internet

### DIFF
--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -103,7 +103,7 @@ datahub-frontend:
         SecRule REQUEST_URI "@contains .profile" "id:1003,phase:1,t:lowercase,nolog,pass,ctl:ruleRemoveById=930130,ctl:ruleRemoveById=930120"
         SecRule REQUEST_HEADERS:Content-Type "^application/json" "id:1004,phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
         SecRule ARGS:json.urn "@contains .profile" "id:1005,phase:2,t:lowercase,nolog,pass,ctl:ruleRemoveById=930130,ctl:ruleRemoveById=930120"
-
+        SecRule REQUEST_URI "@contains nomis_internet" "id:1006,phase:2,t:none,nolog,pass,ctl:ruleRemoveById=933150"
         SecDefaultAction "phase:2,pass,log,tag:github_team=data-catalogue"
         SecDefaultAction "phase:4,pass,log,tag:github_team=data-catalogue"
     tls:


### PR DESCRIPTION
Resolves issue with the following url triggering modsec sensitive data rules. 

https://datahub-catalogue-dev.apps.live.cloud-platform.service.justice.gov.uk/api/gms/aspects/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Aathena%2Cathena_cadet.awsdatacatalog.raw_archive.nomis_internet_addresses%2CPROD%29?aspect=schemaMetadata&version=0

```
{
          "message": "PHP Injection Attack: High-Risk PHP Function Name Found",
          "details": {
            "match": "Matched \"Operator `PmFromFile' with parameter `php-function-names-933150.data' against variable `REQUEST_FILENAME' (Value: `/api/gms/aspects/urn:li:dataset:(urn:li:dataPlatform:athena,athena_cadet.awsdatacatalog.raw_archive. (30 characters omitted)' )",
            "reference": "o103,6v4,150",
            "ruleId": "933150",
            "file": "/etc/nginx/owasp-modsecurity-crs/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf",
            "lineNumber": "313",
            "data": "Matched Data: is_int found within REQUEST_FILENAME: /api/gms/aspects/urn:li:dataset:(urn:li:dataPlatform:athena,athena_cadet.awsdatacatalog.raw_archive.nomis_internet_addresses,PROD)",
            "severity": "2",
            "ver": "OWASP_CRS/4.10.0",
            "rev": "",
            "tags": [
              "github_team=data-catalogue",
              "application-multi",
              "language-php",
              "platform-multi",
              "attack-injection-php",
              "paranoia-level/1",
              "OWASP_CRS",
              "capec/1000/152/242"
            ],
            "maturity": "0",
            "accuracy": "0"
          }
```