### PR TITLE
Fix: improve tag handling in AssignCadetDatabases transformer

### DIFF
--- a/ingestion/transformers/assign_cadet_databases.py
+++ b/ingestion/transformers/assign_cadet_databases.py
@@ -67,10 +67,14 @@ class AssignCadetDatabases(DatasetTransformer, metaclass=ABCMeta):
         domain = self.mappings.get(entity_urn, {}).get("domain")
         if domain:
             subject_area = domains_to_subject_areas.get(domain.lower())
+            subject_area_tag_urn = (
+                mce_builder.make_tag_urn(tag=subject_area) if subject_area else None
+            )
             existing_tags = [tag.tag for tag in in_global_tags_aspect.tags]
-            if subject_area and subject_area not in existing_tags:
+            # Check if the tag already exists
+            if subject_area_tag_urn and subject_area_tag_urn not in existing_tags:
                 tags_to_add = [
-                    TagAssociationClass(tag=mce_builder.make_tag_urn(tag=subject_area)),
+                    TagAssociationClass(tag=subject_area_tag_urn),
                 ]
                 in_global_tags_aspect.tags.extend(tags_to_add)
                 # Keep track of tags added so that we can create them in handle_end_of_stream


### PR DESCRIPTION
The logic for checking existing tags was broken resulting in duplication of tags. 
We were attempting match a partial tag value i.e. `Prisons and probation` in a list of tag urn's `['urn:li:tag:Prisons and probation', 'urn:li:tag:dc_cadet', 'urn:li:tag:dc_display_in_catalogue', 'urn:li:tag:nomis_daily']` which isn't possible.

i.e.
```
>>> existing_tags
['urn:li:tag:Prisons and probation', 'urn:li:tag:dc_cadet', 'urn:li:tag:dc_display_in_catalogue', 'urn:li:tag:nomis_daily']
>>> 'Prisons and probation' in existing_tags
False
>>> 'urn:li:tag:Prisons and probation' in existing_tags
True
```

The code now creates a tag urn before checking it against the existing tags.