### PR TITLE
Fix: add modsec bypass rules for performance_kpis_intermediate and nomis_internet

### DIFF
--- a/helm_deploy/values-base.yaml
+++ b/helm_deploy/values-base.yaml
@@ -105,6 +105,8 @@ datahub-frontend:
         SecRule ARGS:json.urn "@contains .profile" "id:1005,phase:2,t:lowercase,nolog,pass,ctl:ruleRemoveById=930130,ctl:ruleRemoveById=930120"
         SecRule REQUEST_URI "@contains nomis_internet" "id:1006,phase:2,t:none,nolog,pass,ctl:ruleRemoveById=933150"
         SecRule REQUEST_URI "@contains performance_kpis_intermediate" "id:1007,phase:2,t:none,nolog,pass,ctl:ruleRemoveById=933150"
+        SecRule ARGS:json.urn "@contains performance_kpis_intermediate" "id:1008,phase:2,t:lowercase,nolog,pass,ctl:ruleRemoveById=933150"
+        SecRule ARGS:json.urn "@contains nomis_internet" "id:1009,phase:2,t:lowercase,nolog,pass,ctl:ruleRemoveById=933150"
         SecDefaultAction "phase:2,pass,log,tag:github_team=data-catalogue"
         SecDefaultAction "phase:4,pass,log,tag:github_team=data-catalogue"
     tls:


### PR DESCRIPTION
Resolves issues with deletions whereby `performance_kpis_intermediate` and `nomis_internet`trigger the `is_int` function protections in modsec.